### PR TITLE
Remove Scalaz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,6 @@ libraryDependencies ++= {
 
   Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.6.19",
-    "org.scalaz" %% "scalaz-core" % "7.3.6",
     "com.github.scopt" %% "scopt" % "4.0.1",
     "org.typelevel" %% "cats-effect" % "3.3.12",
     //"com.fasterxml" %	"aalto-xml" % "1.1.0-SNAPSHOT",

--- a/src/main/scala/org/exist/xqts/runner/Checksum.scala
+++ b/src/main/scala/org/exist/xqts/runner/Checksum.scala
@@ -22,8 +22,6 @@ import cats.effect.unsafe.IORuntime
 import java.io.InputStream
 import java.nio.file.{Files, Path}
 import java.security.MessageDigest
-import scalaz.\/
-import scalaz.syntax.std.either._
 import cats.effect.{IO, Resource}
 
 import scala.annotation.tailrec
@@ -50,7 +48,7 @@ object Checksum {
     * @param algorithm the algorithm to use for calculating the checksum.
     * @param bufferSize the size of the buffer to use when calculating the checksum (default is 16 KB)
     */
-  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024) : Throwable \/ Array[Byte] = {
+  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024) : Either[Throwable, Array[Byte]] = {
 
     def digestStream(is: InputStream, buf: Array[Byte], digest: MessageDigest): Array[Byte] = {
       @tailrec
@@ -81,7 +79,6 @@ object Checksum {
 
     checksumIO
       .attempt
-      .map(_.toDisjunction)
       .unsafeRunSync()
   }
 

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -29,7 +29,6 @@ import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
 import org.exist.xqts.runner.XQTSParserActor.Spec.Spec
 import org.exist.xqts.runner.XQTSParserActor.XmlVersion.XmlVersion
 import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
-import scalaz.\/
 
 import scala.annotation.unused
 
@@ -48,7 +47,7 @@ trait XQTSParserActor extends Actor {
   * @author Adam Retter <adam@evolvedbinary.com>
   */
 object XQTSParserActor {
-  case class Parse(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], testSets: Set[String] \/ Pattern, testCases: Set[String], excludeTestSets: Set[String], excludeTestCases: Set[String])
+  case class Parse(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], testSets: Either[Set[String], Pattern], testCases: Set[String], excludeTestSets: Set[String], excludeTestCases: Set[String])
   case class ParseComplete(xqtsVersion: XQTSVersion, xqtsPath: Path, matchedTestSets: Int)
 
   object Validation extends Enumeration {
@@ -97,7 +96,7 @@ object XQTSParserActor {
   case class Link(`type`: String, document: String, section: Option[String] = None)
   case class Module(uri: AnyURIValue, file: Path)
   case class Dependency(`type`: DependencyType, value: String, satisfied: Boolean)
-  case class TestCase(file: Path, name: TestCaseName, covers: String, description: Option[String] = None, created: Option[Created] = None, modifications: Seq[Modified] = Seq.empty, environment: Option[Environment] = None, modules: Seq[Module] = Seq.empty, dependencies: Seq[Dependency] = Seq.empty, test: Option[String \/ Path] = None, result: Option[Result] = None)
+  case class TestCase(file: Path, name: TestCaseName, covers: String, description: Option[String] = None, created: Option[Created] = None, modifications: Seq[Modified] = Seq.empty, environment: Option[Environment] = None, modules: Seq[Module] = Seq.empty, dependencies: Seq[Dependency] = Seq.empty, test: Option[Either[String, Path]] = None, result: Option[Result] = None)
   sealed trait Result
 
   /*
@@ -125,8 +124,8 @@ object XQTSParserActor {
   case class AssertSerializationError(expected: String) extends ValueAssertion[String]
   case class AssertStringValue(value: String, normalizeSpace: Boolean) extends Assertion
   case class AssertType(expected: String) extends ValueAssertion[String]
-  case class AssertXml(expected: String \/ Path, ignorePrefixes: Boolean = false) extends ValueAssertion[String \/ Path]
-  case class SerializationMatches(expected: String \/ Path, flags: Option[String] = None) extends ValueAssertion[String \/ Path]
+  case class AssertXml(expected: Either[String, Path], ignorePrefixes: Boolean = false) extends ValueAssertion[Either[String, Path]]
+  case class SerializationMatches(expected: Either[String, Path], flags: Option[String] = None) extends ValueAssertion[Either[String, Path]]
   case object AssertEmpty extends Assertion
   case object AssertTrue extends Assertion
   case object AssertFalse extends Assertion

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -31,7 +31,6 @@ import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
 import org.exist.xqts.runner.XQTSParserActor.{Parse, ParseComplete, TestSetRef}
 import org.exist.xqts.runner.XQTSResultsSerializerActor.{FinalizeSerialization, FinishedSerialization, SerializedTestSetResults, TestSetResults}
 import org.exist.xqts.runner.qt3.XQTS3TestSetParserActor
-import scalaz.\/
 
 import scala.annotation.unused
 import scala.collection.immutable.Map
@@ -254,7 +253,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   * @author Adam Retter <adam@evolvedbinary.com>
   */
 object XQTSRunnerActor {
-  case class RunXQTS(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], maxCacheBytes: Long, testSets: Set[String] \/ Pattern, testCases: Set[String], excludeTestSets: Set[String], excludeTestCases: Set[String])
+  case class RunXQTS(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], maxCacheBytes: Long, testSets: Either[Set[String], Pattern], testCases: Set[String], excludeTestSets: Set[String], excludeTestCases: Set[String])
 
   case class ParsingTestSet(testSetRef: TestSetRef)
   case class ParsedTestSet(testSetRef: TestSetRef, testCases: Seq[String])

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -40,7 +40,6 @@ import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
 import org.exist.xqts.runner.XQTSParserActor.{missingDependencies, _}
 import org.exist.xqts.runner.XQTSRunnerActor.{ParsedTestSet, ParsingTestSet, RanTestCase, RunningTestCase}
 import org.exist.xqts.runner.qt3.XQTS3TestSetParserActor._
-import scalaz.syntax.either._
 
 import scala.annotation.tailrec
 
@@ -395,7 +394,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           captureText = true
 
         case END_ELEMENT if (currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_TEST) =>
-          currentTestCase = currentTestCase.map(testCase => testCase.copy(test = currentText.flatMap(text => Some(text.left[Path])).orElse(currentFile.map(_.right[String]))))
+          currentTestCase = currentTestCase.map(testCase => testCase.copy(test = currentText.flatMap(text => Some(Left(text))).orElse(currentFile.map(Right(_)))))
           currentFile = None
           currentText = None
           captureText = false
@@ -516,8 +515,8 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
 
         case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_XML) =>
           currentText
-              .flatMap(text => Some(text.left[Path]))
-              .orElse(currentFile.map(_.right[String]))
+              .flatMap(text => Some(Left(text)))
+              .orElse(currentFile.map(Right(_)))
               .map(AssertXml(_, currentIgnorePrefixes.getOrElse(false))) match {
             case Some(assertXml) =>
               currentResult = currentResult.map(addAssertion(_)(assertXml))
@@ -531,8 +530,8 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
 
         case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_SERIALIZATION_MATCHES) =>
           currentText
-            .flatMap(text => Some(text.left[Path]))
-            .orElse(currentFile.map(_.right[String]))
+            .flatMap(text => Some(Left(text)))
+            .orElse(currentFile.map(Right(_)))
             .map(SerializationMatches(_, currentFlags)) match {
             case Some(serializationMatched) =>
               currentResult = currentResult.map(addAssertion(_)(serializationMatched))


### PR DESCRIPTION
We previously used Scalaz for its right-biased Disjunction (i.e. `\/`).
Scalaz seems to no longer be popular, many people are now using Cats instead (on which we already have a dependency for `IO`).

Since Scala 2.12.x, Scala's own disjunction type, `Either`, is now right biased so for the most part we can just use that. Cats provides some additional Applicatives for Either which can replace our other uses of Scalaz.