### PR TITLE
Transform support 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target/
 work/
+/project/metals.sbt

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -151,12 +151,11 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     * @param availableCollections Any dynamically available Collections that should be available to the XQuery.
     * @param availableTextResources Any dynamically available Text Resources that should be available to the XQuery.
     * @param externalVariables Any external variables that should be bound for the XQuery.
-    * @param documentVariables Any documents to be available as external variables for the XQuery.
     * @param decimalFormats Any changes to the `unnamed` decimal format.
     *
     * @return the result or executing the query, or an exception.
     */
-  def executeQuery(query: String, cacheCompiled: Boolean, staticBaseUri: Option[String], contextSequence: Option[Sequence], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, documentVariables: Seq[(String, DocumentImpl)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false) : ExistServerException \/ Result = {
+  def executeQuery(query: String, cacheCompiled: Boolean, staticBaseUri: Option[String], contextSequence: Option[Sequence], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false) : ExistServerException \/ Result = {
     /**
       * Gets the XQuery Pool.
       *
@@ -364,7 +363,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       *
       * @param context The XQuery Context to configure
       */
-    def setupContext(context: XQueryContext)(staticBaseUri: Option[String], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, documentVariables: Seq[(String, DocumentImpl)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false): XQueryContext = {
+    def setupContext(context: XQueryContext)(staticBaseUri: Option[String], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false): XQueryContext = {
 
       // Turn on/off XPath 1.0 backwards compatibility.
       context.setBackwardsCompatibility(xpath1Compatibility)
@@ -405,11 +404,6 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
         context.declareVariable(name, value)
       }
 
-      // bind documents with variable roles as external variables
-      for ((name, value) <- documentVariables) {
-        context.declareVariable(name, value)
-      }
-
       // modify/create the decimal formats
       for (df <- decimalFormats ) {
         val unnamedDecimalFormat = context.getStaticDecimalFormat(null)
@@ -440,7 +434,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     val source = new StringSource(query)
-    val fnConfigureContext: XQueryContext => XQueryContext = setupContext(_)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, documentVariables, decimalFormats, modules, xpath1Compatibility)
+    val fnConfigureContext: XQueryContext => XQueryContext = setupContext(_)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, decimalFormats, modules, xpath1Compatibility)
 
     val res: IO[\/[ExistServerException, Result]] =
       SingleThreadedExecutorPool.newResource().use { singleThreadedExecutor =>

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -151,11 +151,12 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     * @param availableCollections Any dynamically available Collections that should be available to the XQuery.
     * @param availableTextResources Any dynamically available Text Resources that should be available to the XQuery.
     * @param externalVariables Any external variables that should be bound for the XQuery.
+    * @param documentVariables Any documents to be available as external variables for the XQuery.
     * @param decimalFormats Any changes to the `unnamed` decimal format.
     *
     * @return the result or executing the query, or an exception.
     */
-  def executeQuery(query: String, cacheCompiled: Boolean, staticBaseUri: Option[String], contextSequence: Option[Sequence], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false) : ExistServerException \/ Result = {
+  def executeQuery(query: String, cacheCompiled: Boolean, staticBaseUri: Option[String], contextSequence: Option[Sequence], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, documentVariables: Seq[(String, DocumentImpl)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false) : ExistServerException \/ Result = {
     /**
       * Gets the XQuery Pool.
       *
@@ -363,7 +364,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       *
       * @param context The XQuery Context to configure
       */
-    def setupContext(context: XQueryContext)(staticBaseUri: Option[String], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false): XQueryContext = {
+    def setupContext(context: XQueryContext)(staticBaseUri: Option[String], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, documentVariables: Seq[(String, DocumentImpl)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false): XQueryContext = {
 
       // Turn on/off XPath 1.0 backwards compatibility.
       context.setBackwardsCompatibility(xpath1Compatibility)
@@ -404,6 +405,11 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
         context.declareVariable(name, value)
       }
 
+      // bind documents with variable roles as external variables
+      for ((name, value) <- documentVariables) {
+        context.declareVariable(name, value)
+      }
+
       // modify/create the decimal formats
       for (df <- decimalFormats ) {
         val unnamedDecimalFormat = context.getStaticDecimalFormat(null)
@@ -434,7 +440,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     val source = new StringSource(query)
-    val fnConfigureContext: XQueryContext => XQueryContext = setupContext(_)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, decimalFormats, modules, xpath1Compatibility)
+    val fnConfigureContext: XQueryContext => XQueryContext = setupContext(_)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, documentVariables, decimalFormats, modules, xpath1Compatibility)
 
     val res: IO[\/[ExistServerException, Result]] =
       SingleThreadedExecutorPool.newResource().use { singleThreadedExecutor =>

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -410,8 +410,12 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
           case \/-(results) =>
             x.role
               .flatMap(role => resolvedEnvironment.resolvedSources.find(_.path == x.file)
-                .map(resolvedSource => (role, resolvedSource.data))
-                .map { case (role, data) => SAXParser.parseXml(data).map(doc => (role.asInstanceOf[ExternalVariableRole].name, doc)) }
+                .map(resolvedSource => (role, resolvedSource.data, resolvedSource.path))
+                .map { case (role, data, path) => SAXParser.parseXml(data).map(doc => {
+                  doc.setDocumentURI(path.toUri().toString())
+                  (role.asInstanceOf[ExternalVariableRole].name, doc)
+                }
+                ) }
               )
               .map(_.map(result => result +: results))
               .getOrElse(-\/(ExistServerException(new IllegalStateException(s"Could not resolve source ${x.file}"))))

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -380,7 +380,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   private def getDynamicContextAvailableDocuments(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : ExistServerException \/ List[(String, DocumentImpl)] = {
     val initAccum: ExistServerException \/ List[(String, DocumentImpl)] = \/-(List.empty)
     testCase.environment
-      .map(env => env.sources.filter(source => source.role.isEmpty && source.uri.nonEmpty))
+      .map(env => env.sources.filter(source => source.uri.nonEmpty))
       .getOrElse(List.empty)
       .foldLeft(initAccum) { case (accum, x) =>
         accum match {

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -237,6 +237,8 @@ object XQTSParserActor {
     val StaticTyping = FeatureVal("staticTyping")
     val TypedData = FeatureVal("typedData")
     val XPath_1_0_Compatibility = FeatureVal("xpath-1.0-compatibility")
+    val TransformXSLT = FeatureVal("fn-transform-XSLT")
+    val TransformXSLT_30 = FeatureVal("fn-transform-XSLT30")
   }
 
   /**

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -92,7 +92,9 @@ object XQTSRunner {
     Serialization,
     StaticTyping,
     TypedData,
-    XPath_1_0_Compatibility
+    XPath_1_0_Compatibility,
+    TransformXSLT,
+    TransformXSLT_30
   )
 
   /**

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -566,6 +566,8 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentResult = None
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_TEST_CASE) =>
+          currentTestCase = currentTestCase.map(testCase => testCase.copy(environment = 
+            if (testCase.environment.isEmpty) { Some(new Environment(testCase.name)) } else { testCase.environment }))
           currentTestCase match {
             case Some(testCase) =>
               if (testCases.isEmpty || testCases.contains(testCase.name)) {

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -566,8 +566,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentResult = None
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_TEST_CASE) =>
-          currentTestCase = currentTestCase.map(testCase => testCase.copy(environment = 
-            if (testCase.environment.isEmpty) { Some(new Environment(testCase.name)) } else { testCase.environment }))
+          currentTestCase = currentTestCase.map(testCase => testCase.copy(environment = testCase.environment.orElse(Some(Environment(testCase.name)))))
           currentTestCase match {
             case Some(testCase) =>
               if (testCases.isEmpty || testCases.contains(testCase.name)) {


### PR DESCRIPTION
Extend test runner to add support for correctly executing the `fn-transform test`.

- Add feature flags corresponding to the `fn:transform` XQuery 3.0 features
- Fix some cases where Document  Base URIs were set up by test context but not passed to eXist (added to exist context)
- Fix a case where if the test did not explicitly specify a *context* (either local or global), `static-base-uri` was not being set.