### PR TITLE
Make exist-xqts runner compatible with 7.0.0-SNAPSHOT of exist-db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [8, 11]
+        jdk: [17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v12
+        uses: olafurpg/setup-scala@v14
         with:
-          java-version: "adopt@1.${{ matrix.jdk }}"
+          java-version: "openjdk@1.${{ matrix.jdk }}"
       - name: Coursier cache
         uses: coursier/cache-action@v6
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,28 +9,25 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [17]
+        jdk: [21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v14
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: "openjdk@1.${{ matrix.jdk }}"
-      - name: Coursier cache
-        uses: coursier/cache-action@v6
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+        with:
+          sbt-runner-version: '1.10.11'
       - name: Build
         shell: bash
-        run: sbt -v -Dfile.encoding=UTF-8 assembly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: sbt -v assembly
       - name: Test
         shell: bash
         run: target/scala-2.13/exist-xqts-runner-assembly-*-SNAPSHOT.jar --xqts-version HEAD --test-set fn-current-date
-      - name: Cleanup before cache
-        shell: bash
-        run: |
-            rm -rf "$HOME/.ivy2/local" || true
-            find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
-            find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-            find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-            find $HOME/.sbt                              -name "*.lock"               -delete || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea/
+.bsp/
 *.iml
 target/
 work/
 /project/metals.sbt
+.DS_Store
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -12,16 +12,21 @@ This application executes a W3C XQTS against an embedded eXist-db server.
 To build from source you will need the following pre-requisites:
 
 1. Git Command Line tools.
-2. Java 8+
-3. SBT (Simple Build Tool) 1.5.5+
+2. Java 21
+3. SBT (Simple Build Tool) 1.10.11
+4. a Github personal access token (PAT) with public read access
 
-In the following steps, we assume that all of the above tools are available on your system path.
+In the following steps, we assume that git, java and sbt are available on your system path.
 
 The version of eXist-db that the XQTS driver is compiled for is set in `build.sbt`. If you wish to compile against a newer or custom version of eXist-db, you can modify this to the version of an eXist-db Maven/Ivy artifact which you have available to your system, e.g.:
 
 ```scala
-val existV = "5.3.0"
+val existV = "7.0.0-SNAPSHOT"
 ``` 
+
+If you set the version to a SNAPSHOT version you want to load from Github Maven Package repository you need to authenticate with the Github PAT.
+
+It can be provided via a credentials file in ~/.ivy2/.credentials or by setting the environment variable `GITHUB_TOKEN`.
 
 Once the pre-requisites are met, to build from source you can execute the following commands from your console/terminal:
 
@@ -58,10 +63,20 @@ Given the standalone application, you can execute it by running either:
 2. or, even by just executing the `exist-xqts-runner-assembly-1.0.0.jar` file directly, as we compile an executable header into the Jar file. e.g. (on Linux/Mac): `./exist-xqts-runner-assembly-1.0.0.jar`.
 
 
-## Publishing to Maven Central / Evolved Binary Snapshots
+## Publishing 
+
+Releases are published to  Maven Central
+Snaphots are published to Github Maven Package repository
+
 1. Run `sbt clean release`
 2. Answer the questions
 3. Login to https://oss.sonatype.org/ then Close, and Release the Staging Repository
+
+You can also publish to your local m2 repository which is useful for testing new builds within existdb's xqts-runner sub-project.
+
+```sh
+sbt publishM2
+```
 
 ## XQTS Results
 The results of executing the XQTS will be formatted as JUnit test output.

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= {
   Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.6.20",
     "com.github.scopt" %% "scopt" % "4.0.1",
-    "org.typelevel" %% "cats-effect" % "3.4.5",
+    "org.typelevel" %% "cats-effect" % "3.4.6",
     //"com.fasterxml" %	"aalto-xml" % "1.1.0-SNAPSHOT",
     "org.exist-db.thirdparty.com.fasterxml" %	"aalto-xml" % "1.1.0-20180330",
     "org.parboiled" %% "parboiled" % "2.4.1",

--- a/build.sbt
+++ b/build.sbt
@@ -51,14 +51,13 @@ libraryDependencies ++= {
     //"com.fasterxml" %	"aalto-xml" % "1.1.0-SNAPSHOT",
     "org.exist-db.thirdparty.com.fasterxml" %	"aalto-xml" % "1.1.0-20180330",
     "org.parboiled" %% "parboiled" % "2.4.1",
-    "org.clapper" %% "grizzled-slf4j" % "1.3.4" exclude("org.slf4j", "slf4j-api"),
     "org.apache.ant" % "ant-junit" % "1.10.13",   // used for formatting junit style report
 
     "net.sf.saxon" % "Saxon-HE" % "9.9.1-8",
     "org.exist-db" % "exist-core" % existV exclude("org.eclipse.jetty.toolchain", "jetty-jakarta-servlet-api"),
     "org.xmlunit" % "xmlunit-core" % "2.9.1",
 
-    "org.slf4j" % "slf4j-api" % "2.0.6" % "runtime",
+    "org.slf4j" % "slf4j-api" % "2.0.6",
     "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.19.0" % "runtime"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ developers := List(
 versionScheme := Some("semver-spec")
 
 libraryDependencies ++= {
-  val existV = "6.1.0"
+  val existV = "7.0.0-SNAPSHOT"
 
   Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.6.20",
@@ -55,7 +55,7 @@ libraryDependencies ++= {
     "org.apache.ant" % "ant-junit" % "1.10.13",   // used for formatting junit style report
 
     "net.sf.saxon" % "Saxon-HE" % "9.9.1-8",
-    "org.exist-db" % "exist-core" % existV,
+    "org.exist-db" % "exist-core" % existV exclude("org.eclipse.jetty.toolchain", "jetty-jakarta-servlet-api"),
     "org.xmlunit" % "xmlunit-core" % "2.9.1",
 
     "org.slf4j" % "slf4j-api" % "2.0.6" % "runtime",
@@ -78,7 +78,9 @@ resolvers ++= Seq(
   "eXist-db Maven Repo" at "https://raw.github.com/eXist-db/mvn-repo/master/"
 )
 
-scalacOptions ++= Seq("-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused")
+javacOptions ++= Seq("-source", "17", "-target", "17")
+
+scalacOptions ++= Seq("-target:jvm-17", "-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused")
 
 // Fancy up the Assembly JAR
 Compile / packageBin / packageOptions +=  {
@@ -91,6 +93,7 @@ Compile / packageBin / packageOptions +=  {
   val gitTag = s"git name-rev --tags --name-only $gitCommit".!!.trim
 
   val additional = Map(
+    "Multi-Release" -> "true",  /* Required by log4j2 on JDK 11 and newer */
     "Build-Timestamp" -> new SimpleDateFormat("yyyyMMddHHmmss").format(Calendar.getInstance.getTime),
     "Built-By" -> sys.props("user.name"),
     "Build-Tag" -> gitTag,

--- a/build.sbt
+++ b/build.sbt
@@ -45,20 +45,20 @@ libraryDependencies ++= {
   val existV = "7.0.0-SNAPSHOT"
 
   Seq(
-    "com.typesafe.akka" %% "akka-actor" % "2.6.20",
-    "com.github.scopt" %% "scopt" % "4.0.1",
-    "org.typelevel" %% "cats-effect" % "3.4.6",
-    //"com.fasterxml" %	"aalto-xml" % "1.1.0-SNAPSHOT",
+    "com.typesafe.akka" %% "akka-actor" % "2.8.1-M1",
+    "com.github.scopt" %% "scopt" % "4.1.0",
+    "org.typelevel" %% "cats-effect" % "3.6.3",
+    // "com.fasterxml" %	"aalto-xml" % "1.3.4",
     "org.exist-db.thirdparty.com.fasterxml" %	"aalto-xml" % "1.1.0-20180330",
-    "org.parboiled" %% "parboiled" % "2.4.1",
-    "org.apache.ant" % "ant-junit" % "1.10.13",   // used for formatting junit style report
+    "org.parboiled" %% "parboiled" % "2.5.1",
+    "org.apache.ant" % "ant-junit" % "1.10.15",   // used for formatting junit style report
 
     "net.sf.saxon" % "Saxon-HE" % "9.9.1-8",
-    "org.exist-db" % "exist-core" % existV exclude("org.eclipse.jetty.toolchain", "jetty-jakarta-servlet-api"),
-    "org.xmlunit" % "xmlunit-core" % "2.9.1",
+    "org.exist-db" % "exist-core" % existV changing() exclude("org.eclipse.jetty.toolchain", "jetty-jakarta-servlet-api"),
+    "org.xmlunit" % "xmlunit-core" % "2.11.0",
 
-    "org.slf4j" % "slf4j-api" % "2.0.6",
-    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.19.0" % "runtime"
+    "org.slf4j" % "slf4j-api" % "2.0.17",
+    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.25.2" % "runtime",
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "exist-xqts-runner"
 
 organization := "org.exist-db"
 
-scalaVersion := "2.13.16"
+scalaVersion := "2.13.17"
 
 semanticdbEnabled := true
 
@@ -51,7 +51,7 @@ libraryDependencies ++= {
   val existV = "7.0.0-SNAPSHOT"
 
   Seq(
-    "com.typesafe.akka" %% "akka-actor" % "2.8.1-M1",
+    "org.apache.pekko" %% "pekko-actor" % "1.3.0",
     "com.github.scopt" %% "scopt" % "4.1.0",
     "org.typelevel" %% "cats-effect" % "3.6.3",
     // "com.fasterxml" %	"aalto-xml" % "1.3.4",

--- a/build.sbt
+++ b/build.sbt
@@ -72,9 +72,8 @@ excludeDependencies ++= Seq(
 
 resolvers ++= Seq(
   Resolver.mavenLocal,
-  "eXist-db Releases" at "https://repo.evolvedbinary.com/repository/exist-db/",
-  "eXist-db Snapshots" at "https://repo.evolvedbinary.com/repository/exist-db-snapshots/",
-  "eXist-db Maven Repo" at "https://raw.github.com/eXist-db/mvn-repo/master/"
+  "eXist-db Releases" at "https://repo.exist-db.org/repository/exist-db/",
+  "Github Package Registry" at "https://maven.pkg.github.com/exist-db/exist",
 )
 
 javacOptions ++= Seq("-source", "21", "-target", "21")
@@ -137,15 +136,19 @@ Compile / assembly / artifact := {
 addArtifact(Compile / assembly / artifact, assembly)
 
 // Publish to Maven Repo
-
 publishMavenStyle := true
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+// Use GitHub Packages if GITHUB_TOKEN is set, otherwise use local connection in credentials file
+credentials += {
+  sys.env.get("GITHUB_TOKEN") match {
+    case Some(token) => Credentials("GitHub Package Registry", "maven.pkg.github.com", "_", token)
+    case _ => Credentials(Path.userHome / ".ivy2" / ".credentials")
+  }
+}
 
 publishTo := {
-  val eb = "https://repo.evolvedbinary.com/"
   if (isSnapshot.value)
-    Some("snapshots" at eb + "repository/exist-db-snapshots/")
+    Some("snapshots" at "https://maven.pkg.github.com/exist-db/exist-xqts-runner")
   else
     Some(Opts.resolver.sonatypeStaging)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ resolvers ++= Seq(
 
 javacOptions ++= Seq("-source", "21", "-target", "21")
 
-scalacOptions ++= Seq("-target:jvm-21", "-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused")
+scalacOptions ++= Seq("-target:jvm-21", "-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused", "-Xlint")
 
 // Fancy up the Assembly JAR
 Compile / packageBin / packageOptions +=  {
@@ -111,11 +111,12 @@ Compile / packageBin / packageOptions +=  {
     attributes.putValue(k, v)
   Package.JarManifest(manifest)
 }
-
 // assembly merge strategy for duplicate files from dependencies
 assembly / assemblyMergeStrategy := {
-  case PathList("org", "exist", "xquery", "lib", "xqsuite", "xqsuite.xql")       => MergeStrategy.first
-  case x if x.equals("module-info.class") || x.endsWith(s"${java.io.File.separatorChar}module-info.class")    => MergeStrategy.discard
+  case PathList("META-INF", "versions", "9" ,"OSGI-INF", "MANIFEST.MF") => MergeStrategy.discard
+  case PathList("META-INF", "versions", "9" ,"module-info.class") => MergeStrategy.discard
+  case PathList("org", "exist", "xquery", "lib", "xqsuite", "xqsuite.xql") => MergeStrategy.first
+  case x if x.equals("module-info.class") || x.endsWith(s"${java.io.File.separatorChar}module-info.class") => MergeStrategy.discard
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "exist-xqts-runner"
 
 organization := "org.exist-db"
 
-scalaVersion := "2.13.8"
+scalaVersion := "2.13.16"
 
 semanticdbEnabled := true
 
@@ -77,9 +77,9 @@ resolvers ++= Seq(
   "eXist-db Maven Repo" at "https://raw.github.com/eXist-db/mvn-repo/master/"
 )
 
-javacOptions ++= Seq("-source", "17", "-target", "17")
+javacOptions ++= Seq("-source", "21", "-target", "21")
 
-scalacOptions ++= Seq("-target:jvm-17", "-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused")
+scalacOptions ++= Seq("-target:jvm-21", "-encoding", "utf-8", "-deprecation", "-feature", "-Ywarn-unused")
 
 // Fancy up the Assembly JAR
 Compile / packageBin / packageOptions +=  {

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,12 @@ developers := List(
     name  = "Adam Retter",
     email = "adam@evolvedbinary.com",
     url   = url("https://www.evolvedbinary.com")
+  ),
+  Developer(
+    id    = "line0",
+    name  = "Juri Leino",
+    email = "juri@existsolutions.com",
+    url   = url("http://existsolutions.com")
   )
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 logLevel := Level.Warn
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.2")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addDependencyTreePlugin

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,7 +26,7 @@ xqtsrunner {
   }
 }
 
-akka {
+pekko {
 
   loglevel = INFO
   stdout-loglevel = INFO

--- a/src/main/resources/conf.xml
+++ b/src/main/resources/conf.xml
@@ -12,8 +12,8 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
             lock-manager
             repository
@@ -25,6 +25,8 @@
             serializer
             transformer
             validation
+                entity-resolver
+                grammar-cache
             xquery
                 builtin-modules
                     module
@@ -192,10 +194,10 @@
         <startup>
             <triggers>
 
-		<!--
-		    Trigger for registering the GNU Crypto JCE Provider with Java
-		-->
-		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+        <!--
+            Trigger for registering the GNU Crypto JCE Provider with Java
+        -->
+        <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -247,10 +249,7 @@
                 - size:                                                                  
                     number of copies of the same query kept in the query-pool.           
                     Value "-1" effectively disables caching. Queries cannot be shared     
-                    by threads, each thread needs a private copy of a query.             
-                                                                                         
-                - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool in milliseconds.
+                    by threads, each thread needs a private copy of a query.
             -->
         <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
@@ -372,10 +371,26 @@
 
             This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
                 or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
     -->
     <lock-manager
             upgrade-check="false"
-            warn-wait-on-read-for-write="false">
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
 
         <!--
             Settings for the Lock Table
@@ -403,39 +418,20 @@
         <lock-table disabled="false" trace-stack-depth="0"/>
 
 
-        <!--
-            Settings for Collection Locking
-
-            - multiple-writers
-                Set to true to enable Multi-Writer/Multi-Reader semantics for
-                the Collection Hierarchy as opposed to the default (false) for Single-Writer/Multi-Reader.
-
-                NOTE: Whilst enabling Multiple-Writers on the Collection Hierarchy can improve concurrent
-                through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
-                Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
-                It is highly recommended that users leave this as the default setting. For more information, see:
-                "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
-                https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
-
-                This can also be set via the Java System Properties `org.exist.lock-manager.collection.multiple-writers`,
-                or (legacy) `exist.lockmanager.collections.multiwriter`.
-        -->
-        <collection multiple-writers="false"/>
-
-
         <!-- Settings for Document Locking
 
-            - multi-lock
-                Set to true to use the "Fast Multi-Level locks" implementation
-                (uk.ac.ic.doc.slurp.multilock.MultiLock) for locking documents, instead of the default of Java's
-                Reentrant Read Write Lock implementation (java.util.concurrent.locks.ReentrantReadWriteLock).
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
 
-                NOTE: At present changing this option has little effect.
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
 
-                This can also be set via the Java System Properties `org.exist.lock-manager.document.multi-lock`,
-                or (legacy) `exist.lockmanager.documents.multilock`.
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
         -->
-        <document multi-lock="false"/>
+        <document use-path-locks="false"/>
 
     </lock-manager>
 
@@ -648,7 +644,7 @@
                 perhaps the best way to do this is to place it into $EXIST_HOME/lib/user
 
                 Examples include:
-                    - org.cyberneko.html.parsers.SAXParser
+                    - org.codelibs.nekohtml.parsers.SAXParser
                         The Cyber NekoHTML parser from https://sourceforge.net/projects/nekohtml/
 
                     - org.ccil.cowan.tagsoup.Parser
@@ -676,11 +672,7 @@
     <parser>
 
         <xml>
-
             <features>
-
-                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
-
                 <!--
                 <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
                 <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
@@ -693,7 +685,7 @@
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
-        <html-to-xml class="org.cyberneko.html.parsers.SAXParser">
+        <html-to-xml class="org.codelibs.nekohtml.parsers.SAXParser">
             <properties>
                 <property name="http://cyberneko.org/html/properties/names/elems" value="match"/>
                 <property name="http://cyberneko.org/html/properties/names/attrs" value="no-change"/>
@@ -719,7 +711,19 @@
            Remember to add a statement like this to your client code:
            service.setProperty("compress-output", "yes");
            to uncompress the retrieved result in the client too.
-        
+
+        - omit-xml-declaration:
+            should the XML Declaration for a document be serialized
+            if it is present?
+
+        - omit-original-xml-declaration:
+            should the original persisted XML Declaration for a document be serialized
+            if it is present?
+
+        - output-doctype:
+            should the Doctype Declaration for a document be serialized
+            if it is present?
+
         - enable-xinclude: 
             should the database expand XInclude tags by default?
         
@@ -745,7 +749,8 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no" enable-xinclude="yes"
-                enable-xsl="no" indent="yes" match-tagging-attributes="no" 
+                omit-xml-declaration="yes" omit-original-xml-declaration="no"
+                output-doctype="yes" enable-xsl="no" indent="yes" match-tagging-attributes="no" 
                 match-tagging-elements="no">
         <!--
             You may add as many custom-filters as you want, they will be executed
@@ -825,6 +830,22 @@
         <entity-resolver>
             <catalog uri="${WEBAPP_HOME}/WEB-INF/catalog.xml"/>
         </entity-resolver>
+
+        <!--
+            Configure XML parser grammar cache. The grammar cache contains
+            compiled versions of XSD and DTD files.
+
+            - size
+                Specifies the maximum number of entries the cache may contain.
+                Value  0: grammars will be evicted immediately after being loaded into the cache.
+                Value -1: no maximum for the number of cached grammars.
+
+            - expire
+                The time (in seconds) after which an unused grammar should expire and be removed
+                from the grammar pool.
+                Value -1: grammars will not be removed over time.
+        -->
+        <grammar-cache size="500" expire="3600"/>
     </validation>
 
     <!-- 
@@ -864,7 +885,6 @@
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>
-
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule" />

--- a/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
@@ -21,7 +21,6 @@ import java.io.IOException
 import java.nio.file.Path
 
 import akka.actor.{Actor, ActorRef}
-import grizzled.slf4j.Logger
 import org.exist.xqts.runner.CommonResourceCacheActor._
 import org.exist.xqts.runner.ReadFileActor.{FileContent, FileReadError, ReadFile}
 

--- a/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
@@ -20,7 +20,7 @@ package org.exist.xqts.runner
 import java.io.IOException
 import java.nio.file.Path
 
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import org.exist.xqts.runner.CommonResourceCacheActor._
 import org.exist.xqts.runner.ReadFileActor.{FileContent, FileReadError, ReadFile}
 

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -32,7 +32,6 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{Clock, IO, Resource}
 import cats.syntax.all._
 import com.evolvedbinary.j8fu.function.{QuadFunctionE, TriFunctionE}
-import grizzled.slf4j.Logger
 
 import javax.xml.namespace.QName
 import javax.xml.transform.OutputKeys

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -25,12 +25,12 @@ import org.exist.storage.{DBBroker, XQueryPool}
 import org.exist.test.ExistEmbeddedServer
 import org.exist.util.serializer.XQuerySerializer
 import org.exist.xquery.{CompiledXQuery, Function, XPathException, XQuery, XQueryContext}
+import org.exist.xquery.value.AnyURIValue
 
 import scala.util.{Failure, Success, Try}
 import ExistServer.{CompilationTime, _}
 import cats.effect.unsafe.IORuntime
 import cats.effect.{Clock, IO, Resource}
-import cats.syntax.all._
 import com.evolvedbinary.j8fu.function.{QuadFunctionE, TriFunctionE}
 
 import javax.xml.namespace.QName
@@ -424,7 +424,8 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
 
       for (module <- modules) {
         val fileUri : XmldbURI = XmldbURI.createInternal(module.file.toAbsolutePath.toUri.toString)
-        context.mapModule(module.uri.getStringValue, fileUri)
+        val locations : Array[AnyURIValue] = Array(new AnyURIValue(fileUri))
+        context.importModule(module.uri.getStringValue, null, locations)
       }
 
       context

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -133,7 +133,7 @@ private object ExistConnection {
   * Represents a connection
   * to an eXist-db server, i.e. a {@link org.exist.storage.DBBroker}
   *
-  * @param broker the eXist-db broker to wrap.
+  * @param brokerRes the eXist-db broker to wrap.
   */
 class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
 
@@ -147,12 +147,29 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     * @param availableDocuments Any dynamically available Documents that should be available to the XQuery.
     * @param availableCollections Any dynamically available Collections that should be available to the XQuery.
     * @param availableTextResources Any dynamically available Text Resources that should be available to the XQuery.
+    * @param namespaces Any static namespaces that should be available to the XQuery.
     * @param externalVariables Any external variables that should be bound for the XQuery.
     * @param decimalFormats Any changes to the `unnamed` decimal format.
+    * @param modules Any modules that should be imported for the XQuery.
+    * @param xpath1Compatibility whether XPath 1.0 backwards compatibility should be enabled.
     *
     * @return the result or executing the query, or an exception.
     */
-  def executeQuery(query: String, cacheCompiled: Boolean, staticBaseUri: Option[String], contextSequence: Option[Sequence], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false) : Either[ExistServerException, Result] = {
+  def executeQuery(
+    query: String,
+    cacheCompiled: Boolean,
+    staticBaseUri: Option[String],
+    contextSequence: Option[Sequence],
+    availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty,
+    availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty,
+    availableTextResources: Seq[(String, Charset, String)] = Seq.empty,
+    namespaces: Seq[Namespace] = Seq.empty,
+    externalVariables: Seq[(String, Sequence)] = Seq.empty,
+    decimalFormats: Seq[DecimalFormat] = Seq.empty,
+    modules: Seq[Module] = Seq.empty,
+    xpath1Compatibility : Boolean = false
+  ) : Either[ExistServerException, Result] = {
+
     /**
       * Gets the XQuery Pool.
       *
@@ -200,7 +217,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
         for {
           startCompilationTime <- Clock[IO].realTime.map(_.toMillis)
           maybeCompiledXQuery <- IO.delay(Option(xqueryPool.borrowCompiledXQuery(broker, source)))
-//            .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Borrow"))  // enable for debugging
+          //            .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Borrow"))  // enable for debugging
           maybeCompiledXQueryContext <- IO.delay(maybeCompiledXQuery.map(compiledXQuery => fnConfigureContext(compiledXQuery.getContext)))
           endCompilationTime <- Clock[IO].realTime.map(_.toMillis)
         } yield maybeCompiledXQuery.zip(maybeCompiledXQueryContext).map{ case (compiledXQuery, compiledXQueryContext) => CompiledQuery(compiledXQuery, compiledXQueryContext, endCompilationTime - startCompilationTime)}
@@ -211,7 +228,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
             for {
               _ <- IO.delay(compiledQuery.xqueryContext.runCleanupTasks())
               _ <- IO.delay(xqueryPool.returnCompiledXQuery(source, compiledQuery.compiledXquery))
-//                .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Return"))  // enable for debugging
+            //                .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Return"))  // enable for debugging
             } yield IO.unit
           case None =>
             IO.unit
@@ -233,12 +250,12 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       val xqueryContextRes = Resource.make {
         // build
         IO.delay(fnConfigureContext(new XQueryContext(broker.getBrokerPool())))
-//          .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Build"))  // enable for debugging
+        //          .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Build"))  // enable for debugging
       } {
         // release
         xqueryContext =>
           IO.delay(xqueryContext.runCleanupTasks())
-//            .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Release"))  // enable for debugging
+          //            .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Release"))  // enable for debugging
       }
 
       xqueryContextRes.flatMap { xqueryContext =>
@@ -309,8 +326,18 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       *
       * @return the result of the query, or an exception.
       */
-    def executeCompiledQuery(broker: DBBroker, xqueryService: XQuery, compiledQuery: CompiledQuery, contextSequence: Option[Sequence]): IO[Either[ExistServerException, Result]] = {
-      def execute(broker: DBBroker, compiledQuery: CompiledQuery, executionStartTime: ExecutionTime, contextSequence: Option[Sequence]) : IO[Either[ExistServerException, Result]] = {
+    def executeCompiledQuery(
+      broker: DBBroker,
+      xqueryService: XQuery,
+      compiledQuery: CompiledQuery,
+      contextSequence: Option[Sequence]
+    ): IO[Either[ExistServerException, Result]] = {
+      def execute(
+        broker: DBBroker,
+        compiledQuery: CompiledQuery,
+        executionStartTime: ExecutionTime,
+        contextSequence: Option[Sequence]
+      ) : IO[Either[ExistServerException, Result]] = {
         IO.delay {
           try {
             val resultSequence = xqueryService.execute(broker, compiledQuery.compiledXquery, contextSequence.orNull)
@@ -321,7 +348,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
               Left(ExistServerException(e, compiledQuery.compilationTime, System.currentTimeMillis() - executionStartTime))
           }
         }
-//          .flatTap(_ => IOUtil.printlnExecutionContext("ExecuteQuery"))  // enable for debugging
+        //          .flatTap(_ => IOUtil.printlnExecutionContext("ExecuteQuery"))  // enable for debugging
       }
 
       for {
@@ -360,7 +387,17 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       *
       * @param context The XQuery Context to configure
       */
-    def setupContext(context: XQueryContext)(staticBaseUri: Option[String], availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty, availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty, availableTextResources: Seq[(String, Charset, String)] = Seq.empty, namespaces: Seq[Namespace] = Seq.empty, externalVariables: Seq[(String, Sequence)] = Seq.empty, decimalFormats: Seq[DecimalFormat] = Seq.empty, modules: Seq[Module] = Seq.empty, xpath1Compatibility : Boolean = false): XQueryContext = {
+    def setupContext(context: XQueryContext)(
+      staticBaseUri: Option[String],
+      availableDocuments: Seq[(String, DocumentImpl)],
+      availableCollections: Seq[(String, List[DocumentImpl])],
+      availableTextResources: Seq[(String, Charset, String)],
+      namespaces: Seq[Namespace],
+      externalVariables: Seq[(String, Sequence)],
+      decimalFormats: Seq[DecimalFormat],
+      modules: Seq[Module],
+      xpath1Compatibility : Boolean
+    ): XQueryContext = {
 
       // Turn on/off XPath 1.0 backwards compatibility.
       context.setBackwardsCompatibility(xpath1Compatibility)

--- a/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
@@ -22,7 +22,6 @@ import cats.effect.unsafe.IORuntime
 import java.io.{BufferedOutputStream, OutputStream}
 import java.nio.file.{Files, Path}
 import cats.effect.{IO, Resource}
-import grizzled.slf4j.Logger
 import junit.framework.{AssertionFailedError, Test => JUTest, TestResult => JUTestResult}
 import net.sf.saxon.TransformerFactoryImpl
 import org.apache.tools.ant.Project

--- a/src/main/scala/org/exist/xqts/runner/Logger.scala
+++ b/src/main/scala/org/exist/xqts/runner/Logger.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2018  The eXist Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exist.xqts.runner
+
+import org.slf4j.{Logger => SLF4JLogger, LoggerFactory => SLF4JLoggerFactory}
+
+final class Logger(val logger: SLF4JLogger) {
+
+  @inline final def isInfoEnabled(): Boolean = logger.isInfoEnabled()
+
+  @inline final def isWarnEnabled(): Boolean = logger.isWarnEnabled()
+
+  @inline final def isErrorEnabled(): Boolean = logger.isErrorEnabled()
+
+  @inline final def isDebugEnabled(): Boolean = logger.isDebugEnabled()
+
+  /**
+    * Log a message at INFO level.
+    *
+    * @param msg the message object on which `toString()` will be called.
+    */
+  @inline final def info(msg: => Any): Unit = {
+    if (isInfoEnabled()) {
+      logger.info(msg.toString)
+    }
+  }
+
+  /**
+    * Log a message with an exception at INFO level.
+    *
+    * @param msg the message object on which `toString()` will be called.
+    * @param t   the exception to include in the log.
+    */
+  @inline final def info(msg: => Any, t: => Throwable): Unit = {
+    if (isInfoEnabled()) {
+      logger.info(s"$msg", t)
+    }
+  }
+
+  /**
+    * Log a message at WARN level.
+    *
+    * @param msg the message object on which `toString()` will be called.
+    */
+  @inline final def warn(msg: => Any): Unit = {
+    if (isWarnEnabled()) {
+      logger.warn(msg.toString)
+    }
+  }
+
+  /**
+    * Log a message at ERROR level.
+    *
+    * @param msg the message object on which `toString()` will be called.
+    */
+  @inline final def error(msg: => Any): Unit = {
+    if (isErrorEnabled()) {
+      logger.error(msg.toString)
+    }
+  }
+
+  /**
+    * Log a message at DEBUG level.
+    *
+    * @param msg the message object on which `toString()` will be called.
+    */
+  @inline final def debug(msg: => Any): Unit = {
+    if (isDebugEnabled()) {
+      logger.debug(msg.toString)
+    }
+  }
+}
+
+object Logger {
+
+  /** Get the logger for the specified class.
+    *
+    * @param clazz  the class
+    *
+    * @return the `Logger`.
+    */
+  def apply(clazz: Class[_]): Logger = new Logger(SLF4JLoggerFactory.getLogger(clazz))
+}

--- a/src/main/scala/org/exist/xqts/runner/Logger.scala
+++ b/src/main/scala/org/exist/xqts/runner/Logger.scala
@@ -21,65 +21,89 @@ import org.slf4j.{Logger => SLF4JLogger, LoggerFactory => SLF4JLoggerFactory}
 
 final class Logger(val logger: SLF4JLogger) {
 
-  @inline final def isInfoEnabled(): Boolean = logger.isInfoEnabled()
+  @inline def isInfoEnabled(): Boolean = logger.isInfoEnabled()
 
-  @inline final def isWarnEnabled(): Boolean = logger.isWarnEnabled()
+  @inline def isWarnEnabled(): Boolean = logger.isWarnEnabled()
 
-  @inline final def isErrorEnabled(): Boolean = logger.isErrorEnabled()
+  @inline def isErrorEnabled(): Boolean = logger.isErrorEnabled()
 
-  @inline final def isDebugEnabled(): Boolean = logger.isDebugEnabled()
+  @inline def isDebugEnabled(): Boolean = logger.isDebugEnabled()
 
   /**
-    * Log a message at INFO level.
-    *
-    * @param msg the message object on which `toString()` will be called.
-    */
-  @inline final def info(msg: => Any): Unit = {
+   * Log a message at INFO level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   */
+  @inline def info(msg: => Any): Unit = {
     if (isInfoEnabled()) {
       logger.info(msg.toString)
     }
   }
 
   /**
-    * Log a message with an exception at INFO level.
-    *
-    * @param msg the message object on which `toString()` will be called.
-    * @param t   the exception to include in the log.
-    */
-  @inline final def info(msg: => Any, t: => Throwable): Unit = {
+   * Log a message with an exception at INFO level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   * @param t   the exception to include in the log.
+   */
+  @inline def info(msg: => Any, t: => Throwable): Unit = {
     if (isInfoEnabled()) {
       logger.info(s"$msg", t)
     }
   }
 
   /**
-    * Log a message at WARN level.
-    *
-    * @param msg the message object on which `toString()` will be called.
-    */
-  @inline final def warn(msg: => Any): Unit = {
+   * Log a message at WARN level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   */
+  @inline def warn(msg: => Any): Unit = {
     if (isWarnEnabled()) {
       logger.warn(msg.toString)
     }
   }
 
   /**
-    * Log a message at ERROR level.
-    *
-    * @param msg the message object on which `toString()` will be called.
-    */
-  @inline final def error(msg: => Any): Unit = {
+   * Log a message with an exception at WARN level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   * @param t   the exception to include in the log.
+   */
+  @inline def warn(msg: => Any, t: => Throwable): Unit = {
+    if (isInfoEnabled()) {
+      logger.warn(s"$msg", t)
+    }
+  }
+
+  /**
+   * Log a message at ERROR level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   */
+  @inline def error(msg: => Any): Unit = {
     if (isErrorEnabled()) {
       logger.error(msg.toString)
     }
   }
 
   /**
-    * Log a message at DEBUG level.
-    *
-    * @param msg the message object on which `toString()` will be called.
-    */
-  @inline final def debug(msg: => Any): Unit = {
+   * Log a message with an exception at ERROR level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   * @param t   the exception to include in the log.
+   */
+  @inline def error(msg: => Any, t: => Throwable): Unit = {
+    if (isInfoEnabled()) {
+      logger.error(s"$msg", t)
+    }
+  }
+
+  /**
+   * Log a message at DEBUG level.
+   *
+   * @param msg the message object on which `toString()` will be called.
+   */
+  @inline def debug(msg: => Any): Unit = {
     if (isDebugEnabled()) {
       logger.debug(msg.toString)
     }
@@ -89,10 +113,10 @@ final class Logger(val logger: SLF4JLogger) {
 object Logger {
 
   /** Get the logger for the specified class.
-    *
-    * @param clazz  the class
-    *
-    * @return the `Logger`.
-    */
+   *
+   * @param clazz  the class
+   *
+   * @return the `Logger`.
+   */
   def apply(clazz: Class[_]): Logger = new Logger(SLF4JLoggerFactory.getLogger(clazz))
 }

--- a/src/main/scala/org/exist/xqts/runner/ReadFileActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/ReadFileActor.scala
@@ -19,7 +19,7 @@ package org.exist.xqts.runner
 
 import java.io.IOException
 import java.nio.file.{Files, Path}
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.either._

--- a/src/main/scala/org/exist/xqts/runner/Settings.scala
+++ b/src/main/scala/org/exist/xqts/runner/Settings.scala
@@ -17,7 +17,7 @@
 
 package org.exist.xqts.runner
 
-import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import org.apache.pekko.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import com.typesafe.config.Config
 import scala.jdk.CollectionConverters._;
 

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -33,7 +33,6 @@ import java.util.regex.Pattern
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.either._
-import grizzled.slf4j.Logger
 import org.exist.dom.memtree.DocumentImpl
 import org.exist.xqts.runner.AssertTypeParser.TypeNode.{ExistTypeDescription, ExplicitExistTypeDescription, WildcardExistTypeDescription}
 import org.exist.xqts.runner.CommonResourceCacheActor.{CachedResource, GetResource, ResourceGetError}

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -448,7 +448,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
           case Some(selectExpr) =>
             `type` match {
-              case Type.EMPTY =>
+              case Type.EMPTY_SEQUENCE =>
               Right(Sequence.EMPTY_SEQUENCE)
 
               case _ =>
@@ -1169,7 +1169,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
       // query result returned an empty sequence
       case Right(Success(expectedType)) if (actual.isEmpty) =>
-        if (expectedType == WildcardExistTypeDescription || expectedType.asInstanceOf[ExplicitExistTypeDescription].base == Type.EMPTY) {
+        if (expectedType == WildcardExistTypeDescription || expectedType.asInstanceOf[ExplicitExistTypeDescription].base == Type.EMPTY_SEQUENCE) {
           // OK, we expected empty
           PassResult(testSetName, testCaseName, compilationTime, executionTime)
         } else {

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -20,7 +20,7 @@ package org.exist.xqts.runner
 import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import org.exist.xqts.runner.TestCaseRunnerActor.RunTestCase
 import org.exist.xqts.runner.XQTSParserActor._
 import TestCaseRunnerActor._

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -237,7 +237,20 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
             getDynamicContextAvailableCollections(connection)(testCase, resolvedEnvironment).flatMap(availableCollections =>
               getDynamicContextAvailableTextResources(connection)(testCase, resolvedEnvironment).flatMap(availableTextResources =>
                 getVariableDeclarations(connection)(testCase, resolvedEnvironment).flatMap(variableDeclarations =>
-                  connection.executeQuery(queryString, false, baseUri, contextSequence, availableDocuments, availableCollections, availableTextResources, testCase.environment.map(_.namespaces).getOrElse(List.empty), variableDeclarations, testCase.environment.map(_.decimalFormats).getOrElse(List.empty), testCase.modules, testCase.dependencies.filter(_.`type` == DependencyType.Feature).headOption.nonEmpty)
+                  connection.executeQuery(
+                    queryString, 
+                    false,
+                    baseUri,
+                    contextSequence,
+                    availableDocuments,
+                    availableCollections,
+                    availableTextResources,
+                    testCase.environment.map(_.namespaces).getOrElse(List.empty),
+                    variableDeclarations,
+                    testCase.environment.map(_.decimalFormats).getOrElse(List.empty),
+                    testCase.modules,
+                    testCase.dependencies.filter(_.`type` == DependencyType.Feature).headOption.nonEmpty
+                  )
                 )
               )
             )
@@ -458,7 +471,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
         }
       }
 
-    val initAccum : Either[ExistServerException, List[(String, Sequence)]] = Right(List.empty)
+      val initAccum : Either[ExistServerException, List[(String, Sequence)]] = Right(List.empty)
 
       testCase.environment
         .map(env => env.params.map(param => (param.name, param.as.map(Type.getType).getOrElse(Type.ANY_TYPE), param.select)))

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -20,7 +20,7 @@ package org.exist.xqts.runner
 import java.net.URI
 import java.nio.file.Path
 import java.util.regex.Pattern
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 
 import javax.xml.namespace.QName
 import net.sf.saxon.value.AnyURIValue

--- a/src/main/scala/org/exist/xqts/runner/XQTSResultsSerializerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSResultsSerializerActor.scala
@@ -17,7 +17,7 @@
 
 package org.exist.xqts.runner
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import org.exist.xqts.runner.TestCaseRunnerActor.TestResult
 import org.exist.xqts.runner.XQTSParserActor.TestSetRef
 

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -24,7 +24,6 @@ import java.util.regex.Pattern
 
 import akka.actor.{ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
-import grizzled.slf4j.Logger
 import org.exist.xqts.runner.Checksum.SHA256
 import org.exist.xqts.runner.XQTSRunner.CmdConfig
 import org.exist.xqts.runner.XQTSRunnerActor.RunXQTS

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -22,7 +22,7 @@ import java.net.{URI, URL}
 import java.nio.file.{Files, Path, Paths}
 import java.util.regex.Pattern
 
-import akka.actor.{ActorSystem, Props}
+import org.apache.pekko.actor.{ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
 import org.exist.xqts.runner.Checksum.SHA256
 import org.exist.xqts.runner.XQTSRunner.CmdConfig

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -22,7 +22,6 @@ import java.util.regex.Pattern
 import akka.actor.{Actor, Props, Timers}
 import XQTSRunnerActor._
 import akka.routing.FromConfig
-import grizzled.slf4j.Logger
 import org.exist.xqts.runner.TestCaseRunnerActor.TestResult
 import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
 import org.exist.xqts.runner.XQTSParserActor.Spec.Spec
@@ -72,7 +71,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
       started = System.currentTimeMillis()
       logger.info(s"Running XQTS: ${XQTSVersion.label(xqtsVersion)}")
 
-      if (logger.isDebugEnabled) {
+      if (logger.isDebugEnabled()) {
         // prints stats about the state of this actor (i.e. test set progress)
         import scala.concurrent.duration._
         timers.startTimerAtFixedRate(TimerStatsKey, TimerPrintStats, 5.seconds)
@@ -159,7 +158,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   }
 
   private def shutdown(): Unit = {
-    if (logger.isDebugEnabled) {
+    if (logger.isDebugEnabled()) {
       timers.cancel(TimerStatsKey)
     }
     context.stop(self)

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -19,9 +19,9 @@ package org.exist.xqts.runner
 
 import java.nio.file.Path
 import java.util.regex.Pattern
-import akka.actor.{Actor, Props, Timers}
+import org.apache.pekko.actor.{Actor, Props, Timers}
 import XQTSRunnerActor._
-import akka.routing.FromConfig
+import org.apache.pekko.routing.FromConfig
 import org.exist.xqts.runner.TestCaseRunnerActor.TestResult
 import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
 import org.exist.xqts.runner.XQTSParserActor.Spec.Spec

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
@@ -27,7 +27,6 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE
 import com.fasterxml.aalto.{AsyncByteBufferFeeder, AsyncXMLStreamReader}
-import grizzled.slf4j.Logger
 
 import javax.xml.stream.XMLStreamConstants.{CHARACTERS, END_DOCUMENT, END_ELEMENT, START_ELEMENT}
 import net.sf.saxon.value.AnyURIValue
@@ -35,7 +34,7 @@ import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
 import org.exist.xqts.runner.XQTSParserActor.Spec.Spec
 import org.exist.xqts.runner.XQTSParserActor.XmlVersion.XmlVersion
 import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
-import org.exist.xqts.runner.{XQTSParseException, XQTSParserActor, XQTSVersion}
+import org.exist.xqts.runner.{Logger, XQTSParseException, XQTSParserActor, XQTSVersion}
 import org.exist.xqts.runner.XQTSParserActor._
 import org.exist.xqts.runner.qt3.XQTS3CatalogParserActor._
 import org.exist.xqts.runner.qt3.XQTS3TestSetParserActor.ParseTestSet

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.{Files, Path}
 import java.util.regex.Pattern
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -26,12 +26,11 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE
 import com.fasterxml.aalto.{AsyncByteBufferFeeder, AsyncXMLStreamReader}
-import grizzled.slf4j.Logger
 
 import javax.xml.namespace.{NamespaceContext, QName}
 import javax.xml.stream.XMLStreamConstants.{CDATA, CHARACTERS, END_DOCUMENT, END_ELEMENT, START_ELEMENT}
 import net.sf.saxon.value.AnyURIValue
-import org.exist.xqts.runner.{Stack, XQTSParseException}
+import org.exist.xqts.runner.{Logger, Stack, XQTSParseException}
 import org.exist.xqts.runner.TestCaseRunnerActor.{AssumptionFailedResult, RunTestCase}
 import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
 import org.exist.xqts.runner.XQTSParserActor.Spec.Spec

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.{Files, Path}
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE

--- a/src/main/scala/org/exist/xqts/runner/qt3/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/package.scala
@@ -112,9 +112,9 @@ package object qt3 {
   /**
     * Adds some convenience methods to {@link AsyncXMLStreamReader}.
     */
-  implicit class AsyncXMLStreamReaderPimp[F <: AsyncInputFeeder](asynXmlStreamReader : AsyncXMLStreamReader[F]) {
-    def getAttributeValue(localName: String) : String = asynXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName)
-    def getAttributeValueOpt(localName: String) : Option[String] = Option(asynXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName))
+  implicit class AsyncXMLStreamReaderPimp[F <: AsyncInputFeeder](asyncXmlStreamReader : AsyncXMLStreamReader[F]) {
+    def getAttributeValue(localName: String) : String = asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName)
+    def getAttributeValueOpt(localName: String) : Option[String] = Option(asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName))
     def getAttributeValueOptNE(localName: String) : Option[String] = getAttributeValueOpt(localName).filter(_.nonEmpty)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.4.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
This is a breaking change as older versions of exist-db cannot use this xqts-runner anymore 

- load exist-core snapshots from Github Maven package repository
- update dependencies
- fix codebase to be compatible with current develop HEAD
- fix module import
- address some linter warnings
- due to Licensing issues the dependency on Akka was replaced with [Apache Pekko](https://pekko.apache.org)