### PR TITLE
chore: reformat code using IDEA formatter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,16 +32,16 @@ scmInfo := Some(ScmInfo(
 
 developers := List(
   Developer(
-    id    = "adamretter",
-    name  = "Adam Retter",
+    id = "adamretter",
+    name = "Adam Retter",
     email = "adam@evolvedbinary.com",
-    url   = url("https://www.evolvedbinary.com")
+    url = url("https://www.evolvedbinary.com")
   ),
   Developer(
-    id    = "line0",
-    name  = "Juri Leino",
+    id = "line0",
+    name = "Juri Leino",
     email = "juri@existsolutions.com",
-    url   = url("http://existsolutions.com")
+    url = url("http://existsolutions.com")
   )
 )
 
@@ -55,9 +55,9 @@ libraryDependencies ++= {
     "com.github.scopt" %% "scopt" % "4.1.0",
     "org.typelevel" %% "cats-effect" % "3.6.3",
     // "com.fasterxml" %	"aalto-xml" % "1.3.4",
-    "org.exist-db.thirdparty.com.fasterxml" %	"aalto-xml" % "1.1.0-20180330",
+    "org.exist-db.thirdparty.com.fasterxml" % "aalto-xml" % "1.1.0-20180330",
     "org.parboiled" %% "parboiled" % "2.5.1",
-    "org.apache.ant" % "ant-junit" % "1.10.15",   // used for formatting junit style report
+    "org.apache.ant" % "ant-junit" % "1.10.15", // used for formatting junit style report
 
     "net.sf.saxon" % "Saxon-HE" % "9.9.1-8",
     "org.exist-db" % "exist-core" % existV changing() exclude("org.eclipse.jetty.toolchain", "jetty-jakarta-servlet-api"),
@@ -67,6 +67,8 @@ libraryDependencies ++= {
     "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.25.2" % "runtime",
   )
 }
+
+autoAPIMappings := true
 
 // we prefer Saxon over Xalan
 excludeDependencies ++= Seq(

--- a/src/main/scala/org/exist/xqts/runner/AssertTypeParser.scala
+++ b/src/main/scala/org/exist/xqts/runner/AssertTypeParser.scala
@@ -34,40 +34,46 @@ object AssertTypeParser {
   sealed trait AstNode
 
   object TypeNode {
-    type ExistCardinalityType = org.exist.xquery.Cardinality  // eXist-db's Cardinality type
-    type ExistTypeType = Int  // eXist-db's XDM type
+    type ExistCardinalityType = org.exist.xquery.Cardinality // eXist-db's Cardinality type
+    type ExistTypeType = Int // eXist-db's XDM type
+
     sealed trait ExistTypeDescription {
-      def hasParameterTypes : Boolean
+      def hasParameterTypes: Boolean
     }
+
     case class ExplicitExistTypeDescription(base: ExistTypeType, parameterTypes: Option[Seq[ExistTypeDescription]], cardinality: Option[ExistCardinality]) extends ExistTypeDescription {
       override def hasParameterTypes = parameterTypes.map(_.nonEmpty).getOrElse(false)
     }
+
     case object WildcardExistTypeDescription extends ExistTypeDescription {
       override def hasParameterTypes = false
     }
   }
+
   sealed trait TypeNode extends AstNode {
     /**
-      * Convert to a representation
-      * which can be used more easily
-      * with eXist-db.
-      *
-      * @return a representation which
-      *  is more easily used with eXist-db
-      */
+     * Convert to a representation
+     * which can be used more easily
+     * with eXist-db.
+     *
+     * @return a representation which
+     *         is more easily used with eXist-db
+     */
     @throws[XPathException]
-    def asExistTypeDescription : ExistTypeDescription
+    def asExistTypeDescription: ExistTypeDescription
   }
 
 
   trait ExplicitTypeNode extends TypeNode {
     def name: TypeNameNode;
+
     def typeParameters: Option[ParametersNode];
+
     def cardinality: Option[CardinalityNode];
 
     @throws[XPathException]
     override def asExistTypeDescription = {
-      def isFunctionType(name: TypeNameNode) : Boolean = {
+      def isFunctionType(name: TypeNameNode): Boolean = {
         name.localName.equals("function") || name.localName.equals("map") || name.localName.equals("array")
       }
 
@@ -92,7 +98,7 @@ object AssertTypeParser {
       ExplicitExistTypeDescription(
         existType,
         typeParameters.map(x => x.parameters.map(y => y.asExistTypeDescription)),
-        cardinality.map(_.cardinality  match {
+        cardinality.map(_.cardinality match {
           case TypeCardinality.* => ExistCardinality.ZERO_OR_MORE
           case TypeCardinality.+ => ExistCardinality.ONE_OR_MORE
           case TypeCardinality.? => ExistCardinality.ZERO_OR_ONE
@@ -112,7 +118,7 @@ object AssertTypeParser {
   }
 
   case class TypeNameNode(prefix: Option[String], localName: String) extends AstNode {
-    def asXdmTypeName : String = prefix.map(_ + ':' + localName).getOrElse(localName)
+    def asXdmTypeName: String = prefix.map(_ + ':' + localName).getOrElse(localName)
   }
 
   case class ParametersNode(parameters: Seq[TypeNode]) extends AstNode
@@ -125,14 +131,13 @@ object AssertTypeParser {
   }
 
   /**
-    * Parses a type description
-    * as expressed in XQTS.
-    *
-    * @param text The complete test to parse.
-    *
-    * @return the parse result.
-    */
-  def parse(text: String) : Try[TypeNode] = {
+   * Parses a type description
+   * as expressed in XQTS.
+   *
+   * @param text The complete test to parse.
+   * @return the parse result.
+   */
+  def parse(text: String): Try[TypeNode] = {
     val normalized = text.trim
     val parseResult = new AssertTypeParser(normalized)
       .InputLine
@@ -142,34 +147,36 @@ object AssertTypeParser {
 }
 
 /**
-  * Simple parser for parsing type descriptions
-  * expressed in XQTS as a String.
-  *
-  * For example:
-  *
-  * document-node()*
-  * xs:boolean
-  * element(employee)
-  * xs:anyURI?
-  * map(*)
-  * map(xs:string, xs:integer)
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Simple parser for parsing type descriptions
+ * expressed in XQTS as a String.
+ *
+ * For example:
+ *
+ * document-node()*
+ * xs:boolean
+ * element(employee)
+ * xs:anyURI?
+ * map(*)
+ * map(xs:string, xs:integer)
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class AssertTypeParser(val input: ParserInput) extends Parser {
 
   /**
-    * Parse all input for a type description.
-    *
-    * @return The parse result
-    */
-  def InputLine = rule { Type ~ EOI }
+   * Parse all input for a type description.
+   *
+   * @return The parse result
+   */
+  def InputLine = rule {
+    Type ~ EOI
+  }
 
   /**
-    * Parse any input, matching the first type description.
-    *
-    * @return The parse result
-    */
+   * Parse any input, matching the first type description.
+   *
+   * @return The parse result
+   */
   def Type: Rule1[TypeNode] = rule {
     WildcardType | ExplicitType
   }
@@ -182,11 +189,11 @@ class AssertTypeParser(val input: ParserInput) extends Parser {
     ExplicitFunctionType | ExplicitNonFunctionType
   }
 
-  private def ExplicitFunctionType : Rule1[ExplicitFunctionTypeNode] = rule {
+  private def ExplicitFunctionType: Rule1[ExplicitFunctionTypeNode] = rule {
     optional("xs:") ~ "function" ~ optional(Parameters) ~ optional(FunctionReturnType) ~ optional(Cardinality) ~> ExplicitFunctionTypeNode
   }
 
-  private def FunctionReturnType : Rule1[TypeNode] = rule {
+  private def FunctionReturnType: Rule1[TypeNode] = rule {
     ws() ~ "as" ~ ws() ~ Type
   }
 
@@ -195,15 +202,15 @@ class AssertTypeParser(val input: ParserInput) extends Parser {
   }
 
 
-  private def TypeName : Rule1[TypeNameNode] = rule {
+  private def TypeName: Rule1[TypeNameNode] = rule {
     optional(Prefix) ~ LocalPart ~> ((prefix: Option[String], localPart: String) => TypeNameNode(prefix, localPart))
   }
 
-  private def Prefix : Rule1[String] = rule {
+  private def Prefix: Rule1[String] = rule {
     capture(oneOrMore(AlphaNum)) ~ ':'
   }
 
-  private def LocalPart : Rule1[String] = rule {
+  private def LocalPart: Rule1[String] = rule {
     capture(oneOrMore(AlphaNum ++ Hyphen))
   }
 
@@ -211,22 +218,22 @@ class AssertTypeParser(val input: ParserInput) extends Parser {
     ch('(') ~ optional(ParameterTypes) ~ ch(')') ~> ((parameterTypes: Option[Seq[TypeNode]]) => ParametersNode(parameterTypes.getOrElse(Seq.empty)))
   }
 
-  private def ParameterTypes : Rule1[Seq[TypeNode]] = rule {
+  private def ParameterTypes: Rule1[Seq[TypeNode]] = rule {
     ParameterType ~ zeroOrMore(ch(',') ~ ws() ~ ParameterType) ~> ((first: TypeNode, others: Seq[TypeNode]) => first +: others)
   }
 
-  private def ParameterType : Rule1[TypeNode] = Type
+  private def ParameterType: Rule1[TypeNode] = Type
 
-  private def Cardinality : Rule1[CardinalityNode] = rule {
+  private def Cardinality: Rule1[CardinalityNode] = rule {
     ch('*') ~> (() => CardinalityNode(TypeCardinality.*)) |
       ch('+') ~> (() => CardinalityNode(TypeCardinality.+)) |
-        ch('?') ~> (() => CardinalityNode(TypeCardinality.?))
+      ch('?') ~> (() => CardinalityNode(TypeCardinality.?))
   }
 
   /**
-    * Whitespace!
-    */
-  private def ws() : Rule0 = rule {
+   * Whitespace!
+   */
+  private def ws(): Rule0 = rule {
     zeroOrMore(CharPredicate(Seq(' ', '\t', '\n', 0x0B.toChar, '\f', '\r')))
   }
 }

--- a/src/main/scala/org/exist/xqts/runner/Checksum.scala
+++ b/src/main/scala/org/exist/xqts/runner/Checksum.scala
@@ -27,32 +27,38 @@ import cats.effect.{IO, Resource}
 import scala.annotation.tailrec
 
 /**
-  * Checksum operations.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Checksum operations.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object Checksum {
 
   sealed trait Algorithm
+
   case object MD2 extends Algorithm
+
   case object MD5 extends Algorithm
+
   case object SHA1 extends Algorithm
+
   case object SHA256 extends Algorithm
+
   case object SHA384 extends Algorithm
+
   case object SHA512 extends Algorithm
 
   /**
-    * Calculates the checksum of a file.
-    * 
-    * @param file the path to the file to checksum
-    * @param algorithm the algorithm to use for calculating the checksum.
-    * @param bufferSize the size of the buffer to use when calculating the checksum (default is 16 KB)
-    */
-  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024) : Either[Throwable, Array[Byte]] = {
+   * Calculates the checksum of a file.
+   *
+   * @param file       the path to the file to checksum
+   * @param algorithm  the algorithm to use for calculating the checksum.
+   * @param bufferSize the size of the buffer to use when calculating the checksum (default is 16 KB)
+   */
+  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024): Either[Throwable, Array[Byte]] = {
 
     def digestStream(is: InputStream, buf: Array[Byte], digest: MessageDigest): Array[Byte] = {
       @tailrec
-      def digestAll() : Unit = {
+      def digestAll(): Unit = {
         val read = is.read(buf)
         if (read == -1) {
           return
@@ -66,11 +72,17 @@ object Checksum {
       digest.digest()
     }
 
-    val checksumIO = Resource.make(IO { Files.newInputStream(file) })(is => IO { is.close() }).use { is =>
+    val checksumIO = Resource.make(IO {
+      Files.newInputStream(file)
+    })(is => IO {
+      is.close()
+    }).use { is =>
       getHash(algorithm).flatMap { digest =>
         // 16 KB buffer
         IO.pure(Array.ofDim[Byte](bufferSize)).flatMap { buf =>
-          IO { digestStream(is, buf, digest) }
+          IO {
+            digestStream(is, buf, digest)
+          }
         }
       }
     }
@@ -83,13 +95,12 @@ object Checksum {
   }
 
   /**
-    * Gets Message Digest algorithm.
-    *
-    * @param algorithm the type of algorith required for a message digest.
-    *
-    * @return the message digest
-    */
-  private def getHash(algorithm: Algorithm) : IO[MessageDigest] = {
+   * Gets Message Digest algorithm.
+   *
+   * @param algorithm the type of algorith required for a message digest.
+   * @return the message digest
+   */
+  private def getHash(algorithm: Algorithm): IO[MessageDigest] = {
     IO {
       algorithm match {
         case MD2 =>

--- a/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/CommonResourceCacheActor.scala
@@ -25,16 +25,15 @@ import org.exist.xqts.runner.CommonResourceCacheActor._
 import org.exist.xqts.runner.ReadFileActor.{FileContent, FileReadError, ReadFile}
 
 /**
-  * Actor which provides an LRU like cache for holding the content of files.
-  *
-  * @param readFileActor An actor which can read files from the filesystem
-  * @param maxCacheBytes The total maximum size for the cache in bytes.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Actor which provides an LRU like cache for holding the content of files.
+ *
+ * @param readFileActor An actor which can read files from the filesystem
+ * @param maxCacheBytes The total maximum size for the cache in bytes.
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class CommonResourceCacheActor(readFileActor: ActorRef, maxCacheBytes: Long) extends Actor {
-  private var cached : Cache = emptyCache
-  private var pending : Pending = nothingPending
+  private var cached: Cache = emptyCache
+  private var pending: Pending = nothingPending
 
   override def receive: Receive = {
     case GetResource(key) =>
@@ -85,22 +84,24 @@ object CommonResourceCacheActor {
   private val nothingPending = Map.empty[Path, List[ActorRef]]
 
   case class GetResource(key: Key)
+
   case class CachedResource(key: Key, value: Value)
+
   case class ResourceGetError(key: Key, error: IOException)
 
 
-  private def addPending(pending: Pending)(key: Key, actor: ActorRef) : Pending = {
+  private def addPending(pending: Pending)(key: Key, actor: ActorRef): Pending = {
     pending + (key ->
       pending.get(key)
         .map(actor +: _)
         .getOrElse(List(actor)))
   }
 
-  private def removePending(pending: Pending)(key: Key) : Pending = pending - key
+  private def removePending(pending: Pending)(key: Key): Pending = pending - key
 
-  private def incrementUseCount(cache: Cache)(key: Key) : Cache = {
+  private def incrementUseCount(cache: Cache)(key: Key): Cache = {
     cache.get(key)
-      .map { case (count, value) => (count + 1, value)}.map(updated => cache + (key -> updated))
+      .map { case (count, value) => (count + 1, value) }.map(updated => cache + (key -> updated))
       .getOrElse(cache)
   }
 
@@ -108,7 +109,7 @@ object CommonResourceCacheActor {
 
   private def cache(cache: Cache)(key: Key, value: TimestampedValue): Cache = cache + (key -> value)
 
-  private def evictAtLeast(cache: Cache)(bytes: Long) : Cache = {
+  private def evictAtLeast(cache: Cache)(bytes: Long): Cache = {
     //TODO(AR) write a tail recursive version
     //@tailrec
     def keysForNBytes(cache: Cache, bytesToClaim: Long): Seq[Key] = {

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -49,21 +49,25 @@ object ExistServer {
 
   object Result {
     def apply(queryError: QueryError, compilationTime: CompilationTime, executionTime: ExecutionTime) = new Result(Left(queryError), compilationTime, executionTime)
+
     def apply(queryResult: QueryResult, compilationTime: CompilationTime, executionTime: ExecutionTime) = new Result(Right(queryResult), compilationTime, executionTime)
   }
+
   case class Result(result: Either[QueryError, QueryResult], compilationTime: CompilationTime, executionTime: ExecutionTime)
 
   type QueryResult = Sequence
+
   object QueryError {
     def apply(xpathException: XPathException) = new QueryError(xpathException.getErrorCode.getErrorQName.getLocalPart, xpathException.getMessage)
   }
+
   case class QueryError(errorCode: String, message: String)
 
   /**
-    * Starts up an eXist-db server.
-    *
-    * @return A reference to the server, or an exception.
-    */
+   * Starts up an eXist-db server.
+   *
+   * @return A reference to the server, or an exception.
+   */
   def start(): Either[Throwable, ExistServer] = {
     val server = new ExistServer
     server.startServer() match {
@@ -74,36 +78,36 @@ object ExistServer {
     }
   }
 
-  def getVersion() : String = org.exist.Version.getVersion()
+  def getVersion(): String = org.exist.Version.getVersion()
 
-  def getCommitAbbrev() : String = {
+  def getCommitAbbrev(): String = {
     val commit = Option(org.exist.Version.getGitCommit()).filter(_.nonEmpty)
     commit.map(_.substring(0, 7)).getOrElse("UNKNOWN")
   }
 }
 
 /**
-  * Encapsulation of operations for an exist-db server.
-  */
+ * Encapsulation of operations for an exist-db server.
+ */
 class ExistServer {
   private val existServer = new ExistEmbeddedServer(true, true)
   private val logger = Logger(classOf[ExistServer])
 
   /**
-    * Starts the eXist-db server.
-    *
-    * @return Success or Failure.
-    */
-  private def startServer() : Try[Unit] = Try(existServer.startDb())
+   * Starts the eXist-db server.
+   *
+   * @return Success or Failure.
+   */
+  private def startServer(): Try[Unit] = Try(existServer.startDb())
 
   /**
-    * Get a connection to the eXist-db server.
-    */
-  def getConnection() : ExistConnection = {
+   * Get a connection to the eXist-db server.
+   */
+  def getConnection(): ExistConnection = {
     val brokerRes = Resource.make {
       // build
       IO.delay(existServer.getBrokerPool.getBroker)
-//        .flatTap(_ => IOUtil.printlnExecutionContext("Broker/Acquire"))  // enable for debugging
+      //        .flatTap(_ => IOUtil.printlnExecutionContext("Broker/Acquire"))  // enable for debugging
     } {
       // release
       broker =>
@@ -111,15 +115,15 @@ class ExistServer {
           logger.warn(s"Error releasing DBBroker: ${t.getMessage}", t)
           IO.unit
         }
-//          .flatTap(_ => IOUtil.printlnExecutionContext("Broker/Release"))  // enable for debugging
+      //          .flatTap(_ => IOUtil.printlnExecutionContext("Broker/Release"))  // enable for debugging
     }
 
     ExistConnection(brokerRes)
   }
 
   /**
-    * Shutdown the eXist-db server.
-    */
+   * Shutdown the eXist-db server.
+   */
   def stopServer(): Unit = {
     existServer.stopDb()
   }
@@ -130,88 +134,84 @@ private object ExistConnection {
 }
 
 /**
-  * Represents a connection
-  * to an eXist-db server, i.e. a {@link org.exist.storage.DBBroker}
-  *
-  * @param brokerRes the eXist-db broker to wrap.
-  */
+ * Represents a connection
+ * to an eXist-db server, i.e. a [[DBBroker]]
+ *
+ * @param brokerRes the eXist-db broker to wrap.
+ */
 class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
 
   /**
-    * Execute an XQuery with eXist-db.
-    *
-    * @param query The XQuery to execute.
-    * @param cacheCompiled true if you want to cache the compiled query form.
-    * @param staticBaseUri An optional static-baseURI for the XQuery.
-    * @param contextSequence An optional context sequence for the XQuery to operate on.
-    * @param availableDocuments Any dynamically available Documents that should be available to the XQuery.
-    * @param availableCollections Any dynamically available Collections that should be available to the XQuery.
-    * @param availableTextResources Any dynamically available Text Resources that should be available to the XQuery.
-    * @param namespaces Any static namespaces that should be available to the XQuery.
-    * @param externalVariables Any external variables that should be bound for the XQuery.
-    * @param decimalFormats Any changes to the `unnamed` decimal format.
-    * @param modules Any modules that should be imported for the XQuery.
-    * @param xpath1Compatibility whether XPath 1.0 backwards compatibility should be enabled.
-    *
-    * @return the result or executing the query, or an exception.
-    */
+   * Execute an XQuery with eXist-db.
+   *
+   * @param query                  The XQuery to execute.
+   * @param cacheCompiled          true if you want to cache the compiled query form.
+   * @param staticBaseUri          An optional static-baseURI for the XQuery.
+   * @param contextSequence        An optional context sequence for the XQuery to operate on.
+   * @param availableDocuments     Any dynamically available Documents that should be available to the XQuery.
+   * @param availableCollections   Any dynamically available Collections that should be available to the XQuery.
+   * @param availableTextResources Any dynamically available Text Resources that should be available to the XQuery.
+   * @param namespaces             Any static namespaces that should be available to the XQuery.
+   * @param externalVariables      Any external variables that should be bound for the XQuery.
+   * @param decimalFormats         Any changes to the `unnamed` decimal format.
+   * @param modules                Any modules that should be imported for the XQuery.
+   * @param xpath1Compatibility    whether XPath 1.0 backwards compatibility should be enabled.
+   * @return the result or executing the query, or an exception.
+   */
   def executeQuery(
-    query: String,
-    cacheCompiled: Boolean,
-    staticBaseUri: Option[String],
-    contextSequence: Option[Sequence],
-    availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty,
-    availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty,
-    availableTextResources: Seq[(String, Charset, String)] = Seq.empty,
-    namespaces: Seq[Namespace] = Seq.empty,
-    externalVariables: Seq[(String, Sequence)] = Seq.empty,
-    decimalFormats: Seq[DecimalFormat] = Seq.empty,
-    modules: Seq[Module] = Seq.empty,
-    xpath1Compatibility : Boolean = false
-  ) : Either[ExistServerException, Result] = {
+                    query: String,
+                    cacheCompiled: Boolean,
+                    staticBaseUri: Option[String],
+                    contextSequence: Option[Sequence],
+                    availableDocuments: Seq[(String, DocumentImpl)] = Seq.empty,
+                    availableCollections: Seq[(String, List[DocumentImpl])] = Seq.empty,
+                    availableTextResources: Seq[(String, Charset, String)] = Seq.empty,
+                    namespaces: Seq[Namespace] = Seq.empty,
+                    externalVariables: Seq[(String, Sequence)] = Seq.empty,
+                    decimalFormats: Seq[DecimalFormat] = Seq.empty,
+                    modules: Seq[Module] = Seq.empty,
+                    xpath1Compatibility: Boolean = false
+                  ): Either[ExistServerException, Result] = {
 
     /**
-      * Gets the XQuery Pool.
-      *
-      * @param broker the database broker.
-      *
-      * @return the XQuery Pool.
-      */
-    def getXQueryPool(broker: DBBroker) : IO[XQueryPool] = {
+     * Gets the XQuery Pool.
+     *
+     * @param broker the database broker.
+     * @return the XQuery Pool.
+     */
+    def getXQueryPool(broker: DBBroker): IO[XQueryPool] = {
       IO.pure(broker.getBrokerPool.getXQueryPool)
     }
 
     /**
-      * Gets the XQuery Service.
-      *
-      * @param broker the database broker.
-      *
-      * @return the XQuery Service.
-      */
-    def getXQueryService(broker: DBBroker) : IO[XQuery] = {
+     * Gets the XQuery Service.
+     *
+     * @param broker the database broker.
+     * @return the XQuery Service.
+     */
+    def getXQueryService(broker: DBBroker): IO[XQuery] = {
       IO.pure(broker.getBrokerPool.getXQueryService)
     }
 
     /**
-      * Data class for a Compiled XQuery.
-      *
-      * @param compiledXquery the compiled query itself.
-      * @param xqueryContext the context prepared for use when executing the compiled query.
-      * @param compilationTime the time it took to compile the XQuery.
-      */
+     * Data class for a Compiled XQuery.
+     *
+     * @param compiledXquery  the compiled query itself.
+     * @param xqueryContext   the context prepared for use when executing the compiled query.
+     * @param compilationTime the time it took to compile the XQuery.
+     */
     case class CompiledQuery(compiledXquery: CompiledXQuery, xqueryContext: XQueryContext, compilationTime: CompilationTime)
 
     /**
-      * Gets a compiled XQuery from an the XQuery Pool.
-      *
-      * @param broker the database broker.
-      * @param xqueryPool the XQuery Pool.
-      * @param source the source of the XQuery.
-      * @param fnConfigureContext a function that can configure the context of the query.
-      *
-      * @return The compiled XQuery from the pool, or None if the pool did not have a compiled query available.
-      */
-    def compiledXQueryFromPool(broker: DBBroker, xqueryPool: XQueryPool, source: Source, fnConfigureContext: XQueryContext => XQueryContext) : Resource[IO, Option[CompiledQuery]] = {
+     * Gets a compiled XQuery from an the XQuery Pool.
+     *
+     * @param broker             the database broker.
+     * @param xqueryPool         the XQuery Pool.
+     * @param source             the source of the XQuery.
+     * @param fnConfigureContext a function that can configure the context of the query.
+     * @return The compiled XQuery from the pool, or None if the pool did not have a compiled query available.
+     */
+    def compiledXQueryFromPool(broker: DBBroker, xqueryPool: XQueryPool, source: Source, fnConfigureContext: XQueryContext => XQueryContext): Resource[IO, Option[CompiledQuery]] = {
       Resource.make {
         // build
         for {
@@ -220,7 +220,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
           //            .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Borrow"))  // enable for debugging
           maybeCompiledXQueryContext <- IO.delay(maybeCompiledXQuery.map(compiledXQuery => fnConfigureContext(compiledXQuery.getContext)))
           endCompilationTime <- Clock[IO].realTime.map(_.toMillis)
-        } yield maybeCompiledXQuery.zip(maybeCompiledXQueryContext).map{ case (compiledXQuery, compiledXQueryContext) => CompiledQuery(compiledXQuery, compiledXQueryContext, endCompilationTime - startCompilationTime)}
+        } yield maybeCompiledXQuery.zip(maybeCompiledXQueryContext).map { case (compiledXQuery, compiledXQueryContext) => CompiledQuery(compiledXQuery, compiledXQueryContext, endCompilationTime - startCompilationTime) }
       } {
         // release
         _ match {
@@ -228,7 +228,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
             for {
               _ <- IO.delay(compiledQuery.xqueryContext.runCleanupTasks())
               _ <- IO.delay(xqueryPool.returnCompiledXQuery(source, compiledQuery.compiledXquery))
-            //                .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Return"))  // enable for debugging
+              //                .flatTap(_ => IOUtil.printlnExecutionContext("CompiledQuery/Return"))  // enable for debugging
             } yield IO.unit
           case None =>
             IO.unit
@@ -237,16 +237,15 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     /**
-      * Compiles an XQuery.
-      *
-      * @param broker the database broker.
-      * @param source the source of the XQuery.
-      * @param fnConfigureContext a function that can configure the context of the query.
-      * @param maybeXQueryPool if present, the query will be returned to the pool after it is used.
-      *
-      * @return The compiled XQuery.
-      */
-    def compileXQuery(broker: DBBroker, source: Source, fnConfigureContext: XQueryContext => XQueryContext, maybeXQueryPool: Option[XQueryPool]) : Resource[IO, CompiledQuery] = {
+     * Compiles an XQuery.
+     *
+     * @param broker             the database broker.
+     * @param source             the source of the XQuery.
+     * @param fnConfigureContext a function that can configure the context of the query.
+     * @param maybeXQueryPool    if present, the query will be returned to the pool after it is used.
+     * @return The compiled XQuery.
+     */
+    def compileXQuery(broker: DBBroker, source: Source, fnConfigureContext: XQueryContext => XQueryContext, maybeXQueryPool: Option[XQueryPool]): Resource[IO, CompiledQuery] = {
       val xqueryContextRes = Resource.make {
         // build
         IO.delay(fnConfigureContext(new XQueryContext(broker.getBrokerPool())))
@@ -255,7 +254,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
         // release
         xqueryContext =>
           IO.delay(xqueryContext.runCleanupTasks())
-          //            .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Release"))  // enable for debugging
+        //            .flatTap(_ => IOUtil.printlnExecutionContext("CompileQuery/Release"))  // enable for debugging
       }
 
       xqueryContextRes.flatMap { xqueryContext =>
@@ -282,62 +281,60 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     /**
-      * Gets a compiled XQuery from an XQuery source.
-      *
-      * Handles caching of compiled XQuery:
-      *
-      *   1. If the cache should be used, then it will try
-      *   and retrieve a compiled version. If there is no
-      *   compiled version, the query source will be
-      *   compiled and added to the cache, before being
-      *   returned.
-      *
-      *   2. If the cache should not be used, then the
-      *   query source will be compiled before being
-      *   returned.
-      *
-      * @param broker the database broker.
-      * @param source the source of the XQuery.
-      * @param fnConfigureContext a function that can configure the context of the query.
-      * @param maybeXQueryPool if present, the query will be returned to the pool after it is used.
-      *
-      * @return The compiled XQuery.
-      */
+     * Gets a compiled XQuery from an XQuery source.
+     *
+     * Handles caching of compiled XQuery:
+     *
+     *   1. If the cache should be used, then it will try
+     *      and retrieve a compiled version. If there is no
+     *      compiled version, the query source will be
+     *      compiled and added to the cache, before being
+     *      returned.
+     *
+     * 2. If the cache should not be used, then the
+     * query source will be compiled before being
+     * returned.
+     *
+     * @param broker             the database broker.
+     * @param source             the source of the XQuery.
+     * @param fnConfigureContext a function that can configure the context of the query.
+     * @param maybeXQueryPool    if present, the query will be returned to the pool after it is used.
+     * @return The compiled XQuery.
+     */
     def compiledXQuery(broker: DBBroker, source: Source, fnConfigureContext: XQueryContext => XQueryContext, maybeXqueryPool: Option[XQueryPool]): Resource[IO, CompiledQuery] = {
       maybeXqueryPool match {
         case Some(xqueryPool) =>
           compiledXQueryFromPool(broker, xqueryPool, source, fnConfigureContext).flatMap { maybeCompiledQueryFromPool =>
             maybeCompiledQueryFromPool match {
-              case Some(compiledQueryFromPool) => Resource.pure(compiledQueryFromPool)            // use the existing query from the pool
-              case None => compileXQuery(broker, source, fnConfigureContext, maybeXqueryPool)     // no existing query in the pool, fallback to compiling a new query
+              case Some(compiledQueryFromPool) => Resource.pure(compiledQueryFromPool) // use the existing query from the pool
+              case None => compileXQuery(broker, source, fnConfigureContext, maybeXqueryPool) // no existing query in the pool, fallback to compiling a new query
             }
           }
-        case None => compileXQuery(broker, source, fnConfigureContext, maybeXqueryPool)           // compile a new query
+        case None => compileXQuery(broker, source, fnConfigureContext, maybeXqueryPool) // compile a new query
       }
     }
 
     /**
-      * Executes a compiled XQuery.
-      *
-      * @param broker the database broker.
-      * @param xqueryService the XQuery Service.
-      * @param compiledQuery the compiled XQuery to execute.
-      * @param contextSequence an optional context sequence for the XQuery to execute over.
-      *
-      * @return the result of the query, or an exception.
-      */
+     * Executes a compiled XQuery.
+     *
+     * @param broker          the database broker.
+     * @param xqueryService   the XQuery Service.
+     * @param compiledQuery   the compiled XQuery to execute.
+     * @param contextSequence an optional context sequence for the XQuery to execute over.
+     * @return the result of the query, or an exception.
+     */
     def executeCompiledQuery(
-      broker: DBBroker,
-      xqueryService: XQuery,
-      compiledQuery: CompiledQuery,
-      contextSequence: Option[Sequence]
-    ): IO[Either[ExistServerException, Result]] = {
+                              broker: DBBroker,
+                              xqueryService: XQuery,
+                              compiledQuery: CompiledQuery,
+                              contextSequence: Option[Sequence]
+                            ): IO[Either[ExistServerException, Result]] = {
       def execute(
-        broker: DBBroker,
-        compiledQuery: CompiledQuery,
-        executionStartTime: ExecutionTime,
-        contextSequence: Option[Sequence]
-      ) : IO[Either[ExistServerException, Result]] = {
+                   broker: DBBroker,
+                   compiledQuery: CompiledQuery,
+                   executionStartTime: ExecutionTime,
+                   contextSequence: Option[Sequence]
+                 ): IO[Either[ExistServerException, Result]] = {
         IO.delay {
           try {
             val resultSequence = xqueryService.execute(broker, compiledQuery.compiledXquery, contextSequence.orNull)
@@ -359,34 +356,31 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     /**
-      * Handler to manage an XPathException
-      * differently from any other type of throwable.
-      *
-      * XPathException will be converted to a {@link Result}
-      * of {@link QueryError}, wilst any other exception
-      * will be converted to an {@link ExistServerException}.
-      *
-      * @param t the exception.
-      * @param compilationTime the time taken to compile the XQuery.
-      * @param executionTime the time taken to execute the XQuery.
-      *
-      * @return either a {@link Result}, or a {@link ExistServerException}.
-      */
-    def fromExecutionException(t: Throwable, compilationTime: CompilationTime, executionTime: ExecutionTime) : Either[ExistServerException, Result] = {
-        if (t.isInstanceOf[XPathException]) {
-          Right(Result(QueryError(t.asInstanceOf[XPathException]), compilationTime, executionTime))
-        } else if (t.isInstanceOf[ExistServerException]) {
-          Left(t.asInstanceOf[ExistServerException]) // pass-through
-        } else {
-          Left(ExistServerException(t, compilationTime, executionTime))
-        }
+     * Handle an XPathException differently from any other type of throwable.
+     *
+     * XPathException will be converted to a [[Result]] of [[QueryError]],
+     * whilst any other exception will be converted to an [[ExistServerException]].
+     *
+     * @param t               the exception.
+     * @param compilationTime the time taken to compile the XQuery.
+     * @param executionTime   the time taken to execute the XQuery.
+     * @return either a [[Result]], or a [[ExistServerException]].
+     */
+    def fromExecutionException(t: Throwable, compilationTime: CompilationTime, executionTime: ExecutionTime): Either[ExistServerException, Result] = {
+      if (t.isInstanceOf[XPathException]) {
+        Right(Result(QueryError(t.asInstanceOf[XPathException]), compilationTime, executionTime))
+      } else if (t.isInstanceOf[ExistServerException]) {
+        Left(t.asInstanceOf[ExistServerException]) // pass-through
+      } else {
+        Left(ExistServerException(t, compilationTime, executionTime))
+      }
     }
 
     /**
-      * Sets up the XQuery Context.
-      *
-      * @param context The XQuery Context to configure
-      */
+     * Sets up the XQuery Context.
+     *
+     * @param context The XQuery Context to configure
+     */
     def setupContext(context: XQueryContext)(
       staticBaseUri: Option[String],
       availableDocuments: Seq[(String, DocumentImpl)],
@@ -396,7 +390,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       externalVariables: Seq[(String, Sequence)],
       decimalFormats: Seq[DecimalFormat],
       modules: Seq[Module],
-      xpath1Compatibility : Boolean
+      xpath1Compatibility: Boolean
     ): XQueryContext = {
 
       // Turn on/off XPath 1.0 backwards compatibility.
@@ -439,7 +433,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       }
 
       // modify/create the decimal formats
-      for (df <- decimalFormats ) {
+      for (df <- decimalFormats) {
         val unnamedDecimalFormat = context.getStaticDecimalFormat(null)
         val modifiedDecimalFormat = new org.exist.xquery.DecimalFormat(
           df.decimalSeparator.getOrElse(unnamedDecimalFormat.decimalSeparator),
@@ -460,8 +454,8 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
       }
 
       for (module <- modules) {
-        val fileUri : XmldbURI = XmldbURI.createInternal(module.file.toAbsolutePath.toUri.toString)
-        val locations : Array[AnyURIValue] = Array(new AnyURIValue(fileUri))
+        val fileUri: XmldbURI = XmldbURI.createInternal(module.file.toAbsolutePath.toUri.toString)
+        val locations: Array[AnyURIValue] = Array(new AnyURIValue(fileUri))
         context.importModule(module.uri.getStringValue, null, locations)
       }
 
@@ -497,15 +491,15 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
   }
 
   // TODO(AR) should return Either[Throwable, String] type
+
   /**
-    * Serializes a Sequence to a String
-    * using Adaptive serialization.
-    *
-    * @param sequence the sequence to serialize.
-    *
-    * @return the result of serializing the sequence.
-    */
-  def sequenceToStringAdaptive(sequence: Sequence) : String = {
+   * Serializes a Sequence to a String
+   * using Adaptive serialization.
+   *
+   * @param sequence the sequence to serialize.
+   * @return the result of serializing the sequence.
+   */
+  def sequenceToStringAdaptive(sequence: Sequence): String = {
     val outputProperties = new Properties()
     outputProperties.setProperty(OutputKeys.METHOD, "adaptive") // improves the output for expected value messages
     outputProperties.setProperty(OutputKeys.INDENT, "no")
@@ -513,38 +507,42 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
   }
 
   // TODO(AR) should return Either[Throwable, String] type
+
   /**
-    * Serializes a Sequence to a String
-    * using XML serialization.
-    *
-    * @param sequence the sequence to serialize.
-    *
-    * @return the result of serializing the sequence.
-    */
-  def sequenceToString(sequence: Sequence) : String = {
+   * Serializes a Sequence to a String
+   * using XML serialization.
+   *
+   * @param sequence the sequence to serialize.
+   * @return the result of serializing the sequence.
+   */
+  def sequenceToString(sequence: Sequence): String = {
     sequenceToString(sequence, new Properties())
   }
 
   // TODO(AR) should return Either[Throwable, String] type
+
   /**
-    * Serializes a Sequence to a String.
-    *
-    * If the serialization method is not
-    * set in the properties, the the XML
-    * method will be used.
-    *
-    * @param sequence the sequence to serialize.
-    * @param outputProperties the serialization settings.
-    *
-    * @return the result of serializing the sequence.
-    */
+   * Serializes a Sequence to a String.
+   *
+   * If the serialization method is not
+   * set in the properties, the the XML
+   * method will be used.
+   *
+   * @param sequence         the sequence to serialize.
+   * @param outputProperties the serialization settings.
+   * @return the result of serializing the sequence.
+   */
   def sequenceToString(sequence: Sequence, outputProperties: Properties): String = {
 
     val res: IO[String] = SingleThreadedExecutorPool.newResource().use { singleThreadedExecutor =>
       val writerRes =
         for {
           broker <- brokerRes
-          writer <- Resource.make(IO.delay { new StringWriter() })(writer => IO.delay { writer.close() })
+          writer <- Resource.make(IO.delay {
+            new StringWriter()
+          })(writer => IO.delay {
+            writer.close()
+          })
         } yield (broker, writer)
 
       writerRes.evalOn(singleThreadedExecutor.executionContext).use {
@@ -553,7 +551,7 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
             val serializer = new XQuerySerializer(broker, outputProperties, writer)
             serializer.serialize(sequence)
             writer.getBuffer.toString
-              .replace("\r", "").replace("\n", ", ")  // further improves the output for expected value messages
+              .replace("\r", "").replace("\n", ", ") // further improves the output for expected value messages
           }.evalOn(singleThreadedExecutor.executionContext)
       }
     }

--- a/src/main/scala/org/exist/xqts/runner/IOUtil.scala
+++ b/src/main/scala/org/exist/xqts/runner/IOUtil.scala
@@ -20,7 +20,7 @@ package org.exist.xqts.runner
 import cats.effect.IO
 
 object IOUtil {
-  def printlnExecutionContext(label: String) : IO[Unit] = {
+  def printlnExecutionContext(label: String): IO[Unit] = {
     IO.executionContext.flatMap(ec => IO.println((label, ec)))
   }
 }

--- a/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
@@ -34,25 +34,27 @@ import org.apache.tools.ant.types.FileSet
 import org.exist.xqts.runner.XQTSParserActor.TestSetName
 
 /**
-  * Actor which serialized test results to the JUnit XML report format.
-  * It can also aggregate a number of XML reports into a HTML report.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Actor which serialized test results to the JUnit XML report format.
+ * It can also aggregate a number of XML reports into a HTML report.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) extends XQTSResultsSerializerActor {
 
   private val logger = Logger(classOf[JUnitResultsSerializerActor])
 
   override def receive: Receive = {
 
-    case testSetResults : TestSetResults =>
+    case testSetResults: TestSetResults =>
       logger.info(s"Serializing results for TestSet: ${testSetResults.testSetRef.name} (${testSetResults.testSetRef.file})...")
       val serializeIo: IO[Option[Throwable]] = dataDir
         .flatMap(dataFile(_, testSetResults.testSetRef.name))
         .flatMap(dataFileOutput(_)
           .use(formatJunitTestSet(testSetResults, _)))
         .map(_ => None)
-        .handleErrorWith(t => IO.pure { Some(t) })
+        .handleErrorWith(t => IO.pure {
+          Some(t)
+        })
 
       implicit val runtime = IORuntime.global
 
@@ -69,7 +71,9 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
     case FinalizeSerialization =>
       val start = System.currentTimeMillis()
       val aggregateIO: IO[Either[Throwable, Path]] = dataDir
-        .flatTap(dd => IO { logger.info(s"Aggregating results report from: ${dd.toAbsolutePath}...") })
+        .flatTap(dd => IO {
+          logger.info(s"Aggregating results report from: ${dd.toAbsolutePath}...")
+        })
         .product(htmlDir)
         .flatTap { case (dataDir, htmlDir) => aggregateJUnitReports(dataDir, htmlDir) }
         .map { case (_, htmlDir) => htmlDir }
@@ -89,13 +93,13 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
       sender() ! FinishedSerialization
   }
 
-  private def dataDir : IO[Path] = IO {
+  private def dataDir: IO[Path] = IO {
     val dataDir = outputDir.resolve("junit").resolve("data")
     Files.createDirectories(dataDir)
     dataDir
   }
 
-  private def htmlDir : IO[Path] = IO {
+  private def htmlDir: IO[Path] = IO {
     val htmlDir = outputDir.resolve("junit").resolve("html")
     Files.createDirectories(htmlDir)
     htmlDir
@@ -105,8 +109,12 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
     dir.resolve("TEST-" + testSetName + ".xml")
   }
 
-  private def dataFileOutput(dataFile: Path) : Resource[IO, _ <: OutputStream] = {
-    Resource.make(IO { new BufferedOutputStream(Files.newOutputStream(dataFile)) })(os => IO { os.close()})
+  private def dataFileOutput(dataFile: Path): Resource[IO, _ <: OutputStream] = {
+    Resource.make(IO {
+      new BufferedOutputStream(Files.newOutputStream(dataFile))
+    })(os => IO {
+      os.close()
+    })
   }
 
   private def formatJunitTestSet(testSetResults: TestSetResults, os: OutputStream) = IO {
@@ -154,12 +162,12 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
     junitResultFormatter.endTestSuite(junitTestSet)
   }
 
-  private def asJavaHashtable[K, V](map: Map[K, V]) : java.util.Hashtable[K, V] = {
+  private def asJavaHashtable[K, V](map: Map[K, V]): java.util.Hashtable[K, V] = {
     import scala.jdk.CollectionConverters._
     new java.util.Hashtable(map.asJava)
   }
 
-  private def aggregateJUnitReports(dataDir: Path, htmlDir: Path) : IO[Unit] = IO {
+  private def aggregateJUnitReports(dataDir: Path, htmlDir: Path): IO[Unit] = IO {
     val project = new Project()
     project.setProperty("java.io.tmpdir", System.getProperty("java.io.tmpdir"))
 
@@ -171,10 +179,10 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
     val aggregator = new XMLResultAggregator()
     aggregator.setProject(project)
     aggregator.addFileSet(fileSet)
-    aggregator.setTodir(dataDir.toFile)   // for the `TESTS-TestSuites.xml` aggregate file
+    aggregator.setTodir(dataDir.toFile) // for the `TESTS-TestSuites.xml` aggregate file
 
     val aggregateTransformer = aggregator.createReport()
-    aggregateTransformer.setTodir(htmlDir.toFile)   // for the HTML reports
+    aggregateTransformer.setTodir(htmlDir.toFile) // for the HTML reports
     aggregateTransformer.createFactory().setName(classOf[TransformerFactoryImpl].getName)
 
     styleDir.map(dir => aggregateTransformer.setStyledir(dir.toAbsolutePath.toFile))
@@ -183,19 +191,19 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
   }
 
   private object XQTSJUnitTest {
-    def apply(testResult : TestResult) = new XQTSJUnitTest(testResult)
+    def apply(testResult: TestResult) = new XQTSJUnitTest(testResult)
   }
 
   private class XQTSJUnitTest(testResult: TestResult) extends JUTest {
     override def countTestCases(): Int = 1
 
-    def getName() : String = testResult.testCase
+    def getName(): String = testResult.testCase
 
-    def getCompilationTime : Long = testResult.compilationTime
+    def getCompilationTime: Long = testResult.compilationTime
 
-    def getExecutionTime : Long = testResult.executionTime
+    def getExecutionTime: Long = testResult.executionTime
 
-    override def run(juTestResult: JUTestResult): Unit =  {}
+    override def run(juTestResult: JUTestResult): Unit = {}
   }
 
   class XQTSXMLJUnitResultFormatter extends XMLJUnitResultFormatter {

--- a/src/main/scala/org/exist/xqts/runner/Logger.scala
+++ b/src/main/scala/org/exist/xqts/runner/Logger.scala
@@ -114,8 +114,7 @@ object Logger {
 
   /** Get the logger for the specified class.
    *
-   * @param clazz  the class
-   *
+   * @param clazz the class
    * @return the `Logger`.
    */
   def apply(clazz: Class[_]): Logger = new Logger(SLF4JLoggerFactory.getLogger(clazz))

--- a/src/main/scala/org/exist/xqts/runner/ReadFileActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/ReadFileActor.scala
@@ -26,11 +26,11 @@ import cats.syntax.either._
 import org.exist.xqts.runner.ReadFileActor.{FileContent, FileReadError, ReadFile}
 
 /**
-  * Actor which reads the entire
-  * content of a file from the filesystem.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Actor which reads the entire
+ * content of a file from the filesystem.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class ReadFileActor extends Actor {
   override def receive: Receive = {
     case ReadFile(path) =>
@@ -42,7 +42,7 @@ class ReadFileActor extends Actor {
       }
   }
 
-  private def readFile(path: Path) : Either[IOException, Array[Byte]] = {
+  private def readFile(path: Path): Either[IOException, Array[Byte]] = {
     val fileIO = IO.blocking {
       Either.catchOnly[IOException](Files.readAllBytes(path))
     }
@@ -54,6 +54,8 @@ class ReadFileActor extends Actor {
 
 object ReadFileActor {
   case class ReadFile(path: Path)
+
   case class FileContent(path: Path, data: Array[Byte])
+
   case class FileReadError(path: Path, error: IOException)
 }

--- a/src/main/scala/org/exist/xqts/runner/SAXParser.scala
+++ b/src/main/scala/org/exist/xqts/runner/SAXParser.scala
@@ -33,15 +33,18 @@ object SAXParser {
   saxParserFactory.setNamespaceAware(true)
 
   /**
-    * Parses a String representation of an XML Document
-    * to an in-memory DOM.
-    *
-    * @param xml the string of xml to parse.
-    *
-    * @return either the Document object, or an exception.
-    */
+   * Parses a String representation of an XML Document
+   * to an in-memory DOM.
+   *
+   * @param xml the string of xml to parse.
+   * @return either the Document object, or an exception.
+   */
   def parseXml(xml: Array[Byte]): Either[ExistServerException, DocumentImpl] = {
-    val xmlRes = Resource.make(IO { new UnsynchronizedByteArrayInputStream(xml) })(is => IO { is.close() })
+    val xmlRes = Resource.make(IO {
+      new UnsynchronizedByteArrayInputStream(xml)
+    })(is => IO {
+      is.close()
+    })
 
     val parseIO = xmlRes.use(is => IO.blocking {
       val saxAdapter = new SAXAdapter()

--- a/src/main/scala/org/exist/xqts/runner/Settings.scala
+++ b/src/main/scala/org/exist/xqts/runner/Settings.scala
@@ -22,13 +22,13 @@ import com.typesafe.config.Config
 import scala.jdk.CollectionConverters._;
 
 /**
-  * Configuration file settings, read from {@code application.conf}.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Configuration file settings, read from {@code application.conf}.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class SettingsImpl(config: Config) extends Extension {
 
-  val xqtsVersions : Map[String, XqtsVersionConfig] = {
+  val xqtsVersions: Map[String, XqtsVersionConfig] = {
     (for (versionConfig <- config.getConfigList("xqtsrunner.xqts.versions").asScala.toSeq)
       yield (versionConfig.getString("version") -> XqtsVersionConfig(
         versionConfig.getString("version"),
@@ -51,6 +51,7 @@ class SettingsImpl(config: Config) extends Extension {
 
 object Settings extends ExtensionId[SettingsImpl] with ExtensionIdProvider {
   override def lookup = Settings
+
   override def createExtension(system: ExtendedActorSystem) =
     new SettingsImpl(system.settings.config)
 }

--- a/src/main/scala/org/exist/xqts/runner/SingleThreadedExecutorPool.scala
+++ b/src/main/scala/org/exist/xqts/runner/SingleThreadedExecutorPool.scala
@@ -25,42 +25,42 @@ import scala.concurrent.ExecutionContext
 case class SingleThreadedExecutor(executorService: ExecutorService, executionContext: ExecutionContext)
 
 /**
-  * eXist-db requires the broker to be acquired, used (e.g XQuery compilation and execution),
-  * and then released by the same thread.
-  *
-  * Therefore we create a SingleThreadExecutorPool whereby we have a pool of
-  * SingleThreadedExecutor that can be used for processing an Acquire, Compile, Execute, and Release
-  * sequence of actions against eXist-db all on the same thread.
-  */
+ * eXist-db requires the broker to be acquired, used (e.g XQuery compilation and execution),
+ * and then released by the same thread.
+ *
+ * Therefore we create a SingleThreadExecutorPool whereby we have a pool of
+ * SingleThreadedExecutor that can be used for processing an Acquire, Compile, Execute, and Release
+ * sequence of actions against eXist-db all on the same thread.
+ */
 object SingleThreadedExecutorPool {
 
   private val brokerExecutorPool = new ConcurrentLinkedDeque[SingleThreadedExecutor]()
 
-  private def createSingleThreadedExecutionContext() : SingleThreadedExecutor = {
+  private def createSingleThreadedExecutionContext(): SingleThreadedExecutor = {
     val executorService = Executors.newSingleThreadExecutor()
     val executionContext = ExecutionContext.fromExecutorService(executorService)
     SingleThreadedExecutor(executorService, executionContext)
   }
 
-  def borrowSingleThreadedExecutor() : SingleThreadedExecutor = {
+  def borrowSingleThreadedExecutor(): SingleThreadedExecutor = {
     val maybeBrokerExecutor = Option(brokerExecutorPool.poll())
     maybeBrokerExecutor.getOrElse(createSingleThreadedExecutionContext())
   }
 
-  def returnSingleThreadedExecutor(singleThreadedExecutor: SingleThreadedExecutor) : Unit = {
+  def returnSingleThreadedExecutor(singleThreadedExecutor: SingleThreadedExecutor): Unit = {
     brokerExecutorPool.push(singleThreadedExecutor)
   }
 
-  def newResource() : Resource[IO, SingleThreadedExecutor] = {
+  def newResource(): Resource[IO, SingleThreadedExecutor] = {
     Resource.make {
       // build
       IO.delay(SingleThreadedExecutorPool.borrowSingleThreadedExecutor())
-//        .flatTap(_ => IOUtil.printlnExecutionContext("SingleThreadedExecutorPool/Build"))  // enable for debugging
+      //        .flatTap(_ => IOUtil.printlnExecutionContext("SingleThreadedExecutorPool/Build"))  // enable for debugging
     } {
       // release
       singleThreadedExecutionContext =>
         IO.delay(SingleThreadedExecutorPool.returnSingleThreadedExecutor(singleThreadedExecutionContext))
-//          .flatTap(_ => IOUtil.printlnExecutionContext("SingleThreadedExecutorPool/Release"))  // enable for debugging
+      //          .flatTap(_ => IOUtil.printlnExecutionContext("SingleThreadedExecutorPool/Release"))  // enable for debugging
     }
   }
 }

--- a/src/main/scala/org/exist/xqts/runner/Stack.scala
+++ b/src/main/scala/org/exist/xqts/runner/Stack.scala
@@ -17,86 +17,82 @@
 
 package org.exist.xqts.runner
 
-import scala.collection.immutable.Nil
-
 /**
-  * A very simple Stack implementation
-  * build atop a {@link List}.
-  *
-  * @param list the list which backs the stack
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * A very simple Stack implementation
+ * build atop a [[List]].
+ *
+ * @param list the list which backs the stack
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class Stack[+A](list: List[A]) {
 
   /**
-    * Constructor for an empty stack.
-    */
+   * Constructor for an empty stack.
+   */
   def this() = this(Nil)
 
   /**
-    * Places a new item onto the top of the stack.
-    *
-    * @param x the new item to place atop the stack.
-    *
-    * @return the new stack.
-    */
-  def push[B >: A](x: B) : Stack[B] = Stack(x :: list)
+   * Places a new item onto the top of the stack.
+   *
+   * @param x the new item to place atop the stack.
+   * @return the new stack.
+   */
+  def push[B >: A](x: B): Stack[B] = Stack(x :: list)
 
   /**
-    * Get a copy of the item at the top of the stack.
-    *
-    * @return the item at the top of the stack.
-    *
-    * @throws NoSuchElementException if the stack is empty
-    */
+   * Get a copy of the item at the top of the stack.
+   *
+   * @return the item at the top of the stack.
+   * @throws NoSuchElementException if the stack is empty
+   */
   @throws[NoSuchElementException]
-  def peek : A = list.head
+  def peek: A = list.head
 
   /**
-    * Get a copy of the item at the top of the stack.
-    *
-    * @return a Some of the item at the top of the stack,
-    *         or a None if the stack is empty
-    */
+   * Get a copy of the item at the top of the stack.
+   *
+   * @return a Some of the item at the top of the stack,
+   *         or a None if the stack is empty
+   */
   def peekOption: Option[A] = list.headOption
 
   /**
-    * Takes item from the top of the stack.
-    *
-    * @return A tuple consisting of: the item from the
-    *         top of the stack, and the new stack
-    *
-    * @throws NoSuchElementException if the stack is empty
-    */
+   * Takes item from the top of the stack.
+   *
+   * @return A tuple consisting of: the item from the
+   *         top of the stack, and the new stack
+   * @throws NoSuchElementException if the stack is empty
+   */
   @throws[NoSuchElementException]
-  def pop() : (A, Stack[A]) = (list.head, Stack(list.tail))
+  def pop(): (A, Stack[A]) = (list.head, Stack(list.tail))
 
   /**
-    * Replaces the item at the top of the stack with a new item.
-    *
-    * @param x the new item for the head
-    * @return the new stack
-    */
-  def replace[B >: A](x: B) : Stack[B] = Stack(x :: list.tail)
+   * Replaces the item at the top of the stack with a new item.
+   *
+   * @param x the new item for the head
+   * @return the new stack
+   */
+  def replace[B >: A](x: B): Stack[B] = Stack(x :: list.tail)
 
   /**
-    * Removes the top item from the stack, and returns the stack.
-    *
-    * @return the new stack
-    */
-  def drop() : Stack[A] = Stack(list.tail)
+   * Removes the top item from the stack, and returns the stack.
+   *
+   * @return the new stack
+   */
+  def drop(): Stack[A] = Stack(list.tail)
 
   /**
-    * Gets the depth of the stack.
-    *
-    * @return the depth of the stack
-    */
+   * Gets the depth of the stack.
+   *
+   * @return the depth of the stack
+   */
   def size: Int = list.size
 }
 
 object Stack {
-  def empty[A] : Stack[A] = new Stack()
-  def apply[A] (head: A) = new Stack(List(head))
-  def apply[A] (list: List[A]) = new Stack(list)
+  def empty[A]: Stack[A] = new Stack()
+
+  def apply[A](head: A) = new Stack(List(head))
+
+  def apply[A](list: List[A]) = new Stack(list)
 }

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -46,15 +46,14 @@ import scala.annotation.unused
 import scala.util.{Failure, Success}
 
 /**
-  * Actor that executes an XQTS test-case
-  * and checks the results against the
-  * assertions specified in the test-case.
-  *
-  * @param existServer The eXist-db server to execute the test case against.
-  * @param commonResourceCacheActor An actor for retrieving common resources.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Actor that executes an XQTS test-case
+ * and checks the results against the
+ * assertions specified in the test-case.
+ *
+ * @param existServer              The eXist-db server to execute the test case against.
+ * @param commonResourceCacheActor An actor for retrieving common resources.
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: ActorRef) extends Actor {
 
   private val logger = Logger(classOf[TestCaseRunnerActor])
@@ -190,36 +189,34 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Execute an XQTS test-case against eXist-db.
-    *
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCase the test-case to execute.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the result of executing the XQTS test-case.
-    */
-  private def runTestCaseWithExist(testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : TestResult = {
-      try {
-        runTestCase(existServer.getConnection(), testSetName, testCase, resolvedEnvironment)
-      } catch {
-        case e: java.lang.OutOfMemoryError =>
-          System.err.println(s"OutOfMemoryError: $testSetName ${testCase.name}")
-          throw e
-      }
+   * Execute an XQTS test-case against eXist-db.
+   *
+   * @param testSetName         the name of the test-set of which the test-case is a part.
+   * @param testCase            the test-case to execute.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the result of executing the XQTS test-case.
+   */
+  private def runTestCaseWithExist(testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
+    try {
+      runTestCase(existServer.getConnection(), testSetName, testCase, resolvedEnvironment)
+    } catch {
+      case e: java.lang.OutOfMemoryError =>
+        System.err.println(s"OutOfMemoryError: $testSetName ${testCase.name}")
+        throw e
+    }
   }
 
   /**
-    * Run's an XQTS test-case against eXist-db.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCase the test-case to execute.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the result of executing the XQTS test-case.
-    */
-    @throws(classOf[OutOfMemoryError])
-  private def runTestCase(connection: ExistConnection, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : TestResult = {
+   * Run's an XQTS test-case against eXist-db.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testSetName         the name of the test-set of which the test-case is a part.
+   * @param testCase            the test-case to execute.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the result of executing the XQTS test-case.
+   */
+  @throws(classOf[OutOfMemoryError])
+  private def runTestCase(connection: ExistConnection, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
     testCase.test match {
       case Some(test) =>
 
@@ -238,7 +235,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
               getDynamicContextAvailableTextResources(connection)(testCase, resolvedEnvironment).flatMap(availableTextResources =>
                 getVariableDeclarations(connection)(testCase, resolvedEnvironment).flatMap(variableDeclarations =>
                   connection.executeQuery(
-                    queryString, 
+                    queryString,
                     false,
                     baseUri,
                     contextSequence,
@@ -269,9 +266,9 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                 testCase.result match {
                   case Some(expectedResult) =>
                     expectedResult match {
-                      case Error(expectedError) if(expectedError == queryError.errorCode) =>
+                      case Error(expectedError) if (expectedError == queryError.errorCode) =>
                         PassResult(testSetName, testCase.name, compilationTime, executionTime)
-                      case anyOf @ AnyOf(_) if(anyOfContainsError(anyOf, queryError.errorCode)) =>
+                      case anyOf@AnyOf(_) if (anyOfContainsError(anyOf, queryError.errorCode)) =>
                         PassResult(testSetName, testCase.name, compilationTime, executionTime)
                       case _ =>
                         FailureResult(testSetName, testCase.name, compilationTime, executionTime, failureMessage(expectedResult, queryError))
@@ -281,12 +278,12 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                 }
 
               // executing query returned a result
-              case Right(queryResult) if(queryResult == null) =>
+              case Right(queryResult) if (queryResult == null) =>
                 ErrorResult(testSetName, testCase.name, compilationTime, executionTime, new IllegalStateException("eXist-db returned null from the query, this should never happen!"))
 
               case Right(queryResult) =>
                 testCase.result match {
-                  case (Some(expectedError: Error)) =>  // expected an error, but got a query result
+                  case (Some(expectedError: Error)) => // expected an error, but got a query result
                     FailureResult(testSetName, testCase.name, compilationTime, executionTime, failureMessage(connection)(expectedError, queryResult))
 
                   case (Some(expectedResult)) =>
@@ -304,16 +301,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Get the context sequence for the XQuery.
-    *
-    * @param connection a connection to an eXist-db server.
-    *
-    * @param testCase a test-case which describes the context sequence.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the context sequence if present, or an exception
-    */
-  private def getContextSequence(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : Either[ExistServerException, Option[Sequence]] = {
+   * Get the context sequence for the XQuery.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testCase            a test-case which describes the context sequence.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the context sequence if present, or an exception
+   */
+  private def getContextSequence(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, Option[Sequence]] = {
     testCase.environment match {
       case Some(env) if (env.name == "empty") =>
         Right(None)
@@ -329,13 +324,12 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Resolves a source from the environment.
-    *
-    * @param resolvedEnvironment the environment resources for the test-case.
-    * @param source the source to resolve from the environment.
-    *
-    * @return the resolved source, or an exception.
-    */
+   * Resolves a source from the environment.
+   *
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @param source              the source to resolve from the environment.
+   * @return the resolved source, or an exception.
+   */
   private def resolveSource(resolvedEnvironment: ResolvedEnvironment, source: Source): Either[ExistServerException, ResolvedSource] = {
     resolvedEnvironment.resolvedSources.find(_.path == source.file)
       .map(Right[ExistServerException, ResolvedSource](_))
@@ -343,28 +337,26 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Get the dynamically available collections for the XQuery Context.
-    *
-    * @param connection a connection to an eXist-db server.
-    *
-    * @param testCase a test-case which describes the dynamically available collections.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the dynamically available collections, or an exception
-    */
-  private def getDynamicContextAvailableCollections(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : Either[ExistServerException, List[(String, List[DocumentImpl])]] = {
+   * Get the dynamically available collections for the XQuery Context.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testCase            a test-case which describes the dynamically available collections.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the dynamically available collections, or an exception
+   */
+  private def getDynamicContextAvailableCollections(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, List[(String, List[DocumentImpl])]] = {
     val initAccum: Either[ExistServerException, List[(String, List[DocumentImpl])]] = Right(List.empty)
     testCase.environment
       .map(env => env.collections)
       .getOrElse(List.empty)
       .foldLeft(initAccum) { case (accum, x) =>
         accum match {
-          case error@ Left(_) => error
+          case error@Left(_) => error
           case Right(results) =>
-            val initInnerAccum : Either[ExistServerException, List[DocumentImpl]] = Right(List.empty)
+            val initInnerAccum: Either[ExistServerException, List[DocumentImpl]] = Right(List.empty)
             x.sources.foldLeft(initInnerAccum) { case (innerAccum, y) =>
                 innerAccum match {
-                  case resolveError@ Left(_) => resolveError
+                  case resolveError@Left(_) => resolveError
                   case Right(resolvedSources) =>
                     resolveSource(resolvedEnvironment, y)
                       .flatMap(resolveSource => SAXParser.parseXml(resolveSource.data))
@@ -379,23 +371,21 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Get the dynamically available documents for the XQuery Context.
-    *
-    * @param connection a connection to an eXist-db server.
-    *
-    * @param testCase a test-case which describes the dynamically available documents.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the dynamically available documents, or an exception
-    */
-  private def getDynamicContextAvailableDocuments(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : Either[ExistServerException, List[(String, DocumentImpl)]] = {
+   * Get the dynamically available documents for the XQuery Context.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testCase            a test-case which describes the dynamically available documents.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the dynamically available documents, or an exception
+   */
+  private def getDynamicContextAvailableDocuments(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, List[(String, DocumentImpl)]] = {
     val initAccum: Either[ExistServerException, List[(String, DocumentImpl)]] = Right(List.empty)
     testCase.environment
       .map(env => env.sources.filter(source => (source.role.isEmpty || source.role.filter(Role.isContextItem(_)).nonEmpty) && source.uri.nonEmpty))
       .getOrElse(List.empty)
       .foldLeft(initAccum) { case (accum, x) =>
         accum match {
-          case error@ Left(_) => error
+          case error@Left(_) => error
           case Right(results) =>
             x.uri
               .flatMap(uri => resolvedEnvironment.resolvedSources.find(_.path == x.file)
@@ -409,17 +399,15 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Get the dynamically available text resources for the XQuery Context.
-    *
-    * @param connection a connection to an eXist-db server.
-    *
-    * @param testCase a test-case which describes the dynamically text resources.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the dynamically available text resources, or an exception
-    */
-  private def getDynamicContextAvailableTextResources(@unused connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment) : Either[ExistServerException, List[(String, Charset, String)]] = {
-    def toString(data: Array[Byte], encoding: Option[String]) : Either[ExistServerException, (Charset, String)] = {
+   * Get the dynamically available text resources for the XQuery Context.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testCase            a test-case which describes the dynamically text resources.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the dynamically available text resources, or an exception
+   */
+  private def getDynamicContextAvailableTextResources(@unused connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, List[(String, Charset, String)]] = {
+    def toString(data: Array[Byte], encoding: Option[String]): Either[ExistServerException, (Charset, String)] = {
       Either.catchNonFatal(encoding.map(Charset.forName).getOrElse(UTF_8))
         .map(charset => (charset, new String(data, charset)))
         .leftMap(ExistServerException(_))
@@ -431,38 +419,36 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
       .getOrElse(List.empty)
       .foldLeft(initAccum) { case (accum, x) =>
         accum match {
-          case error@ Left(_) => error
+          case error@Left(_) => error
           case Right(results) =>
-              resolvedEnvironment.resolvedResources.find(_.path == x.file)
-                .map(resolvedResource => toString(resolvedResource.data, x.encoding).map{ case (charset, string) => (x.uri, charset, string) })
-                .map(_.map(result => result +: results))
-                .getOrElse(Left(ExistServerException(new IllegalStateException(s"Could not resolve resource ${x.file} with encoding ${x.encoding.getOrElse("UTF-8")}"))))
+            resolvedEnvironment.resolvedResources.find(_.path == x.file)
+              .map(resolvedResource => toString(resolvedResource.data, x.encoding).map { case (charset, string) => (x.uri, charset, string) })
+              .map(_.map(result => result +: results))
+              .getOrElse(Left(ExistServerException(new IllegalStateException(s"Could not resolve resource ${x.file} with encoding ${x.encoding.getOrElse("UTF-8")}"))))
         }
       }
   }
 
   /**
-    * Get the external variable declarations for the XQuery Context.
-    *
-    * @param connection a connection to an eXist-db server.
-    *
-    * @param testCase a test-case which describes the external variable declarations.
-    * @param resolvedEnvironment the environment resources for the test-case.
-    *
-    * @return the external variable declarations, or an exception
-    */
+   * Get the external variable declarations for the XQuery Context.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testCase            a test-case which describes the external variable declarations.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the external variable declarations, or an exception
+   */
   private def getVariableDeclarations(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, List[(String, Sequence)]] = {
 
-    def getParams() : Either[ExistServerException, List[(String, Sequence)]] = {
+    def getParams(): Either[ExistServerException, List[(String, Sequence)]] = {
       def variableSelectToSequence(`type`: Int, select: Option[String]): Either[ExistServerException, Sequence] = {
         select match {
           case None =>
-          Right(Sequence.EMPTY_SEQUENCE)
+            Right(Sequence.EMPTY_SEQUENCE)
 
           case Some(selectExpr) =>
             `type` match {
               case Type.EMPTY_SEQUENCE =>
-              Right(Sequence.EMPTY_SEQUENCE)
+                Right(Sequence.EMPTY_SEQUENCE)
 
               case _ =>
                 connection.executeQuery(selectExpr, false, None, None)
@@ -471,15 +457,15 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
         }
       }
 
-      val initAccum : Either[ExistServerException, List[(String, Sequence)]] = Right(List.empty)
+      val initAccum: Either[ExistServerException, List[(String, Sequence)]] = Right(List.empty)
 
       testCase.environment
         .map(env => env.params.map(param => (param.name, param.as.map(Type.getType).getOrElse(Type.ANY_TYPE), param.select)))
         .getOrElse(List.empty)
         .foldLeft(initAccum) { case (accum, (name, typ, select)) =>
           accum match {
-          case error@ Left(_) => error
-          case Right(results) =>
+            case error@Left(_) => error
+            case Right(results) =>
               variableSelectToSequence(typ, select)
                 .map(seq => (name, seq))
                 .map(result => result +: results)
@@ -487,14 +473,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
         }
     }
 
-    def getDocuments() : Either[ExistServerException, List[(String, Sequence)]] = {
+    def getDocuments(): Either[ExistServerException, List[(String, Sequence)]] = {
       val initAccum: Either[ExistServerException, List[(String, Sequence)]] = Right(List.empty)
       testCase.environment
         .map(env => env.sources.filter(source => source.role.filter(_.isInstanceOf[ExternalVariableRole]).nonEmpty))
         .getOrElse(List.empty)
         .foldLeft(initAccum) { case (accum, x) =>
           accum match {
-            case error@ Left(_) => error
+            case error@Left(_) => error
             case Right(results) =>
               x.role
                 .flatMap(role => resolvedEnvironment.resolvedSources.find(_.path == x.file)
@@ -503,7 +489,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                     doc.setDocumentURI(path.toUri().toString())
                     (role.asInstanceOf[ExternalVariableRole].name, doc)
                   }
-                  ) }
+                  )
+                  }
                 )
                 .map(_.map(result => result +: results))
                 .getOrElse(Left(ExistServerException(new IllegalStateException(s"Could not resolve source ${x.file}"))))
@@ -515,15 +502,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Checks if an XQTS any-of assertion contains a specific error assertion.
-    *
-    * @param anyOf the any-of assertion.
-    * @param expectedError the error to search for in the any-of
-    *
-    * @return true if the any-of contains the error, false otherwise.
-    */
-  private def anyOfContainsError(anyOf: AnyOf, expectedError: String) : Boolean = {
-    def expand(result: XQTSParserActor.Result) : List[XQTSParserActor.Result] = {
+   * Checks if an XQTS any-of assertion contains a specific error assertion.
+   *
+   * @param anyOf         the any-of assertion.
+   * @param expectedError the error to search for in the any-of
+   * @return true if the any-of contains the error, false otherwise.
+   */
+  private def anyOfContainsError(anyOf: AnyOf, expectedError: String): Boolean = {
+    def expand(result: XQTSParserActor.Result): List[XQTSParserActor.Result] = {
       Some(result)
         .filter(_.isInstanceOf[Assertions])
         .map(_.asInstanceOf[Assertions])
@@ -539,21 +525,19 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Processes an expected XQTS assertion to compare
-    * it against the actual result of executing an XQuery.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expectedResult the assertion which describes the expected result(s).
-    * @param actualResult the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
-  private def processAssertion(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedResult: XQTSParserActor.Result, actualResult: ExistServer.QueryResult) : TestResult = {
+   * Processes an expected XQTS assertion to compare
+   * it against the actual result of executing an XQuery.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expectedResult  the assertion which describes the expected result(s).
+   * @param actualResult    the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
+  private def processAssertion(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedResult: XQTSParserActor.Result, actualResult: ExistServer.QueryResult): TestResult = {
     expectedResult match {
       case AllOf(assertions) =>
         allOf(connection, testSetName, testCaseName, compilationTime, executionTime)(assertions, actualResult)
@@ -612,35 +596,33 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code all-of} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param assertions the assertions that make up the {@code all-of} assertion.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code all-of} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param assertions      the assertions that make up the {@code all-of} assertion.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def allOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
-    val problem : Option[Either[ErrorResult, FailureResult]] = assertions.foldLeft(Option.empty[Either[ErrorResult, FailureResult]]) { case (failed, assertion) =>
-        if(failed.nonEmpty) {
-          failed
-        } else {
-          processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual) match {
-            case error: ErrorResult =>
-              Some(Left(error))
-            case failure: FailureResult =>
-              Some(Right(failure))
-            case _: PassResult =>
-              None
-            case _: AssumptionFailedResult =>
-              throw new IllegalStateException("Assumption should have already been evaluated")
-          }
+    val problem: Option[Either[ErrorResult, FailureResult]] = assertions.foldLeft(Option.empty[Either[ErrorResult, FailureResult]]) { case (failed, assertion) =>
+      if (failed.nonEmpty) {
+        failed
+      } else {
+        processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual) match {
+          case error: ErrorResult =>
+            Some(Left(error))
+          case failure: FailureResult =>
+            Some(Right(failure))
+          case _: PassResult =>
+            None
+          case _: AssumptionFailedResult =>
+            throw new IllegalStateException("Assumption should have already been evaluated")
         }
+      }
     }
 
     problem.map(e => e.fold(_.asInstanceOf[TestResult], _.asInstanceOf[TestResult]))
@@ -648,28 +630,26 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code any-of} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param assertions the assertions that make up the {@code any-of} assertion.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code any-of} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param assertions      the assertions that make up the {@code any-of} assertion.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def anyOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
-    def passOrFails() : Either[Seq[Either[ErrorResult, FailureResult]], PassResult] = {
+    def passOrFails(): Either[Seq[Either[ErrorResult, FailureResult]], PassResult] = {
       val accum = Either.left[Seq[Either[ErrorResult, FailureResult]], PassResult](Seq.empty[Either[ErrorResult, FailureResult]])
       assertions.foldLeft(accum) { case (results, assertion) =>
         results match {
-          case passed @ Right(_) =>
-            passed  // if we have passed one, we don't need to evaluate any more assertions
+          case passed@Right(_) =>
+            passed // if we have passed one, we don't need to evaluate any more assertions
 
-          case errors @ Left(_) =>
+          case errors@Left(_) =>
             // evaluate the next assertion
             processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual) match {
               case pass: PassResult =>
@@ -696,19 +676,17 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code not} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param assertion the assertion to negate from within the {@code not} assertion.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code not} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param assertion       the assertion to negate from within the {@code not} assertion.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def not(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertion: XQTSParserActor.Result, actual: ExistServer.QueryResult): TestResult = {
     val result = processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual)
     result match {
@@ -722,19 +700,17 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param xpath the xpath to assert.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param xpath           the xpath to assert.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assert(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(xpath: String, actual: ExistServer.QueryResult): TestResult = {
     executeQueryWith$Result(connection, xpath, true, None, actual) match {
       case Left(existServerException) =>
@@ -755,18 +731,16 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-count} assertion.
-    *
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the expected count of results.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-count} assertion.
+   *
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the expected count of results.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertCount(testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: Int, actual: ExistServer.QueryResult): TestResult = {
     val actualCount = actual.getItemCount
     if (expected == actualCount) {
@@ -777,25 +751,24 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-deep-eq} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the expected sequence of results to assert.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-deep-eq} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the expected sequence of results to assert.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertDeepEquals(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
-    val deepEqualQuery = s"""
-                         | declare variable $$result external;
-                         |
-                         | deep-equal(($expected), $$result)
-                         |""".stripMargin
+    val deepEqualQuery =
+      s"""
+         | declare variable $$result external;
+         |
+         | deep-equal(($expected), $$result)
+         |""".stripMargin
     executeQueryWith$Result(connection, deepEqualQuery, true, None, actual) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
@@ -817,25 +790,24 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-eq} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected an XPath which describes that expected result is {@code eq} to the actual result.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-eq} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        an XPath which describes that expected result is {@code eq} to the actual result.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertEq(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
-    val eqQuery = s"""
-                  | declare variable $$result external;
-                  |
-                  | $expected eq $$result
-                  |""".stripMargin
+    val eqQuery =
+      s"""
+         | declare variable $$result external;
+         |
+         | $expected eq $$result
+         |""".stripMargin
     executeQueryWith$Result(connection, eqQuery, false, None, actual) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
@@ -847,8 +819,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
         val totalCompilationTime = compilationTime + resCompilationTime
         val totalExecutionTime = executionTime + resExecutionTime
         if (actualQueryResult.getItemCount == 1
-            && actualQueryResult.itemAt(0).isInstanceOf[BooleanValue]
-            && actualQueryResult.itemAt(0).asInstanceOf[BooleanValue].getValue) {
+          && actualQueryResult.itemAt(0).isInstanceOf[BooleanValue]
+          && actualQueryResult.itemAt(0).asInstanceOf[BooleanValue].getValue) {
           PassResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime)
         } else {
           FailureResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, s"assert-eq: expected='$expected', actual='${connection.sequenceToStringAdaptive(actual)}'")
@@ -857,90 +829,89 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-permutation} assertion.
-    *
-    * This is very similar to {@code assert-deep-eq},
-    * but we sort both the expected and actual results
-    * into the same order first, so that we can
-    * ignore permutations.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the expected sequence of results to assert.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-permutation} assertion.
+   *
+   * This is very similar to {@code assert-deep-eq},
+   * but we sort both the expected and actual results
+   * into the same order first, so that we can
+   * ignore permutations.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the expected sequence of results to assert.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertPermutation(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
-    val expectedQuery = s"""
-                        | declare variable $$result external;
-                        |
-                        | declare function local:xdm-type($$value as item()?) as xs:QName? {
-                        |   typeswitch($$value)
-                        |     case array(*) return xs:QName("array")
-                        |     case map(*) return xs:QName("map")
-                        |     case function(*) return xs:QName("function")
-                        |     case document-node() return xs:QName("document")
-                        |     case element() return xs:QName("element")
-                        |     case attribute() return xs:QName("attribute")
-                        |     case comment() return xs:QName("comment")
-                        |     case processing-instruction() return xs:QName("processing-instruction")
-                        |     case text() return xs:QName("text")
-                        |     case xs:untypedAtomic return xs:QName('xs:untypedAtomic')
-                        |     case xs:anyURI return xs:QName('xs:anyURI')
-                        |     case xs:ENTITY return xs:QName('xs:ENTITY')
-                        |     case xs:ID return xs:QName('xs:ID')
-                        |     case xs:NMTOKEN return xs:QName('xs:NMTOKEN')
-                        |     case xs:language return xs:QName('xs:language')
-                        |     case xs:NCName return xs:QName('xs:NCName')
-                        |     case xs:Name return xs:QName('xs:Name')
-                        |     case xs:token return xs:QName('xs:token')
-                        |     case xs:normalizedString return xs:QName('xs:normalizedString')
-                        |     case xs:string return xs:QName('xs:string')
-                        |     case xs:QName return xs:QName('xs:QName')
-                        |     case xs:boolean return xs:QName('xs:boolean')
-                        |     case xs:base64Binary return xs:QName('xs:base64Binary')
-                        |     case xs:hexBinary return xs:QName('xs:hexBinary')
-                        |     case xs:byte return xs:QName('xs:byte')
-                        |     case xs:short return xs:QName('xs:short')
-                        |     case xs:int return xs:QName('xs:int')
-                        |     case xs:long return xs:QName('xs:long')
-                        |     case xs:unsignedByte return xs:QName('xs:unsignedByte')
-                        |     case xs:unsignedShort return xs:QName('xs:unsignedShort')
-                        |     case xs:unsignedInt return xs:QName('xs:unsignedInt')
-                        |     case xs:unsignedLong return xs:QName('xs:unsignedLong')
-                        |     case xs:positiveInteger return xs:QName('xs:positiveInteger')
-                        |     case xs:nonNegativeInteger return xs:QName('xs:nonNegativeInteger')
-                        |     case xs:negativeInteger return xs:QName('xs:negativeInteger')
-                        |     case xs:nonPositiveInteger return xs:QName('xs:nonPositiveInteger')
-                        |     case xs:integer return xs:QName('xs:integer')
-                        |     case xs:decimal return xs:QName('xs:decimal')
-                        |     case xs:float return xs:QName('xs:float')
-                        |     case xs:double return xs:QName('xs:double')
-                        |     case xs:date return xs:QName('xs:date')
-                        |     case xs:time return xs:QName('xs:time')
-                        |     case xs:dateTime return xs:QName('xs:dateTime')
-                        |     case xs:dayTimeDuration return xs:QName('xs:dayTimeDuration')
-                        |     case xs:yearMonthDuration return xs:QName('xs:yearMonthDuration')
-                        |     case xs:duration return xs:QName('xs:duration')
-                        |     case xs:gMonth return xs:QName('xs:gMonth')
-                        |     case xs:gYear return xs:QName('xs:gYear')
-                        |     case xs:gYearMonth return xs:QName('xs:gYearMonth')
-                        |     case xs:gDay return xs:QName('xs:gDay')
-                        |     case xs:gMonthDay return xs:QName('xs:gMonthDay')
-                        |     default return ()
-                        | };
-                        |
-                        | let $$sort-key-fun := function($$key) {
-                        |   local:xdm-type($$key) || "::" || fn:data($$key)
-                        | }
-                        | return
-                        |   fn:deep-equal(fn:sort(($expected), (), $$sort-key-fun), fn:sort($$result, (), $$sort-key-fun))
-                        |""".stripMargin
+    val expectedQuery =
+      s"""
+         | declare variable $$result external;
+         |
+         | declare function local:xdm-type($$value as item()?) as xs:QName? {
+         |   typeswitch($$value)
+         |     case array(*) return xs:QName("array")
+         |     case map(*) return xs:QName("map")
+         |     case function(*) return xs:QName("function")
+         |     case document-node() return xs:QName("document")
+         |     case element() return xs:QName("element")
+         |     case attribute() return xs:QName("attribute")
+         |     case comment() return xs:QName("comment")
+         |     case processing-instruction() return xs:QName("processing-instruction")
+         |     case text() return xs:QName("text")
+         |     case xs:untypedAtomic return xs:QName('xs:untypedAtomic')
+         |     case xs:anyURI return xs:QName('xs:anyURI')
+         |     case xs:ENTITY return xs:QName('xs:ENTITY')
+         |     case xs:ID return xs:QName('xs:ID')
+         |     case xs:NMTOKEN return xs:QName('xs:NMTOKEN')
+         |     case xs:language return xs:QName('xs:language')
+         |     case xs:NCName return xs:QName('xs:NCName')
+         |     case xs:Name return xs:QName('xs:Name')
+         |     case xs:token return xs:QName('xs:token')
+         |     case xs:normalizedString return xs:QName('xs:normalizedString')
+         |     case xs:string return xs:QName('xs:string')
+         |     case xs:QName return xs:QName('xs:QName')
+         |     case xs:boolean return xs:QName('xs:boolean')
+         |     case xs:base64Binary return xs:QName('xs:base64Binary')
+         |     case xs:hexBinary return xs:QName('xs:hexBinary')
+         |     case xs:byte return xs:QName('xs:byte')
+         |     case xs:short return xs:QName('xs:short')
+         |     case xs:int return xs:QName('xs:int')
+         |     case xs:long return xs:QName('xs:long')
+         |     case xs:unsignedByte return xs:QName('xs:unsignedByte')
+         |     case xs:unsignedShort return xs:QName('xs:unsignedShort')
+         |     case xs:unsignedInt return xs:QName('xs:unsignedInt')
+         |     case xs:unsignedLong return xs:QName('xs:unsignedLong')
+         |     case xs:positiveInteger return xs:QName('xs:positiveInteger')
+         |     case xs:nonNegativeInteger return xs:QName('xs:nonNegativeInteger')
+         |     case xs:negativeInteger return xs:QName('xs:negativeInteger')
+         |     case xs:nonPositiveInteger return xs:QName('xs:nonPositiveInteger')
+         |     case xs:integer return xs:QName('xs:integer')
+         |     case xs:decimal return xs:QName('xs:decimal')
+         |     case xs:float return xs:QName('xs:float')
+         |     case xs:double return xs:QName('xs:double')
+         |     case xs:date return xs:QName('xs:date')
+         |     case xs:time return xs:QName('xs:time')
+         |     case xs:dateTime return xs:QName('xs:dateTime')
+         |     case xs:dayTimeDuration return xs:QName('xs:dayTimeDuration')
+         |     case xs:yearMonthDuration return xs:QName('xs:yearMonthDuration')
+         |     case xs:duration return xs:QName('xs:duration')
+         |     case xs:gMonth return xs:QName('xs:gMonth')
+         |     case xs:gYear return xs:QName('xs:gYear')
+         |     case xs:gYearMonth return xs:QName('xs:gYearMonth')
+         |     case xs:gDay return xs:QName('xs:gDay')
+         |     case xs:gMonthDay return xs:QName('xs:gMonthDay')
+         |     default return ()
+         | };
+         |
+         | let $$sort-key-fun := function($$key) {
+         |   local:xdm-type($$key) || "::" || fn:data($$key)
+         | }
+         | return
+         |   fn:deep-equal(fn:sort(($expected), (), $$sort-key-fun), fn:sort($$result, (), $$sort-key-fun))
+         |""".stripMargin
     executeQueryWith$Result(connection, expectedQuery, true, None, actual) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
@@ -962,19 +933,17 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-serialization-error} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the expected XQuery Error code.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-serialization-error} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the expected XQuery Error code.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertSerializationError(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
     executeQueryWith$Result(connection, QUERY_ASSERT_XML_SERIALIZATION, true, None, actual) match {
       case Left(existServerException) =>
@@ -992,18 +961,16 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-empty} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-empty} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertEmpty(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(actual: ExistServer.QueryResult): TestResult = {
     if (actual.isEmpty) {
       PassResult(testSetName, testCaseName, compilationTime, executionTime)
@@ -1013,21 +980,19 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-false} assertion.
-    *
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-false} assertion.
+   *
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertFalse(testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(actual: ExistServer.QueryResult): TestResult = {
     if (actual.getItemCount == 1
-        && actual.itemAt(0).getType == Type.BOOLEAN
-        && actual.itemAt(0).asInstanceOf[BooleanValue].getValue == false) {
+      && actual.itemAt(0).getType == Type.BOOLEAN
+      && actual.itemAt(0).asInstanceOf[BooleanValue].getValue == false) {
       PassResult(testSetName, testCaseName, compilationTime, executionTime)
     } else {
       FailureResult(testSetName, testCaseName, compilationTime, executionTime, s"assert-false: actual='$actual'")
@@ -1035,17 +1000,15 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-true} assertion.
-    *
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-true} assertion.
+   *
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertTrue(testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(actual: ExistServer.QueryResult): TestResult = {
     if (actual.getItemCount == 1
       && actual.itemAt(0).getType == Type.BOOLEAN
@@ -1057,96 +1020,92 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-string-value} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the expected string value result of the XQuery.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-string-value} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the expected string value result of the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertStringValue(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, normalizeSpace: Boolean, actual: ExistServer.QueryResult): TestResult = {
-      if (normalizeSpace) {
-        // normalize the expected
-        executeQueryWith$Result(connection, QUERY_NORMALIZED_SPACE, true, None, new StringValue(expected)) match {
-          case Left(existServerException) =>
-            ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
+    if (normalizeSpace) {
+      // normalize the expected
+      executeQueryWith$Result(connection, QUERY_NORMALIZED_SPACE, true, None, new StringValue(expected)) match {
+        case Left(existServerException) =>
+          ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
-          case Right(Result(Left(queryError), errExpectedCompilationTime, errExpectedExecutionTime)) =>
-            ErrorResult(testSetName, testCaseName, compilationTime + errExpectedCompilationTime, executionTime + errExpectedExecutionTime, new IllegalStateException(s"Error whilst normalizing expected value: ${queryError.errorCode}: ${queryError.message}"))
+        case Right(Result(Left(queryError), errExpectedCompilationTime, errExpectedExecutionTime)) =>
+          ErrorResult(testSetName, testCaseName, compilationTime + errExpectedCompilationTime, executionTime + errExpectedExecutionTime, new IllegalStateException(s"Error whilst normalizing expected value: ${queryError.errorCode}: ${queryError.message}"))
 
-          case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) =>
-            // get the actual string value and normalize
-            executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE, true, None, actual) match {
-              case Left(existServerException) =>
-                ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + existServerException.compilationTime, executionTime + expectedQueryExecutionTime + existServerException.executionTime, existServerException)
+        case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) =>
+          // get the actual string value and normalize
+          executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE, true, None, actual) match {
+            case Left(existServerException) =>
+              ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + existServerException.compilationTime, executionTime + expectedQueryExecutionTime + existServerException.executionTime, existServerException)
 
-              case Right(Result(Left(queryError), errActualCompilationTime, errActualExecutionTime)) =>
-                ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + errActualCompilationTime, executionTime + expectedQueryExecutionTime + errActualExecutionTime, new IllegalStateException(s"Error whilst processing and normalizing actual value: ${queryError.errorCode}: ${queryError.message}"))
+            case Right(Result(Left(queryError), errActualCompilationTime, errActualExecutionTime)) =>
+              ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + errActualCompilationTime, executionTime + expectedQueryExecutionTime + errActualExecutionTime, new IllegalStateException(s"Error whilst processing and normalizing actual value: ${queryError.errorCode}: ${queryError.message}"))
 
-              case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) =>
+            case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) =>
 
-                val stringExpected : String = expectedQueryResult.asInstanceOf[StringValue].getStringValue()
-                val stringActual : String = actualQueryResult.asInstanceOf[StringValue].getStringValue()
-                val totalCompilationTime = compilationTime + expectedQueryCompilationTime + actualQueryCompilationTime
-                val totalExecutionTime = executionTime + expectedQueryExecutionTime + actualQueryExecutionTime
+              val stringExpected: String = expectedQueryResult.asInstanceOf[StringValue].getStringValue()
+              val stringActual: String = actualQueryResult.asInstanceOf[StringValue].getStringValue()
+              val totalCompilationTime = compilationTime + expectedQueryCompilationTime + actualQueryCompilationTime
+              val totalExecutionTime = executionTime + expectedQueryExecutionTime + actualQueryExecutionTime
 
-                if (stringActual == stringExpected) {
-                  PassResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime)
-                } else {
-                  FailureResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, s"assert-string-value: expected='$stringExpected', actual='$stringActual'")
-                }
-            }
-        }
-
-      } else {
-        // get the actual string value
-        executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE, true, None, actual) match {
-          case Left(existServerException) =>
-            ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
-
-          case Right(Result(Left(queryError), errCompilationTime, errExecutionTime)) =>
-            ErrorResult(testSetName, testCaseName, compilationTime + errCompilationTime, executionTime + errExecutionTime, new IllegalStateException(s"Error whilst processing and normalizing actual value: ${queryError.errorCode}: ${queryError.message}"))
-
-          case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) =>
-            val stringActual : String = actualQueryResult.asInstanceOf[StringValue].getStringValue()
-            val totalCompilationTime = compilationTime + actualQueryCompilationTime
-            val totalExecutionTime = executionTime + actualQueryExecutionTime
-
-            if (stringActual == expected) {
-              PassResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime)
-            } else {
-              FailureResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, s"assert-string-value: expected='$expected', actual='$stringActual'")
-            }
-        }
+              if (stringActual == stringExpected) {
+                PassResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime)
+              } else {
+                FailureResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, s"assert-string-value: expected='$stringExpected', actual='$stringActual'")
+              }
+          }
       }
+
+    } else {
+      // get the actual string value
+      executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE, true, None, actual) match {
+        case Left(existServerException) =>
+          ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
+
+        case Right(Result(Left(queryError), errCompilationTime, errExecutionTime)) =>
+          ErrorResult(testSetName, testCaseName, compilationTime + errCompilationTime, executionTime + errExecutionTime, new IllegalStateException(s"Error whilst processing and normalizing actual value: ${queryError.errorCode}: ${queryError.message}"))
+
+        case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) =>
+          val stringActual: String = actualQueryResult.asInstanceOf[StringValue].getStringValue()
+          val totalCompilationTime = compilationTime + actualQueryCompilationTime
+          val totalExecutionTime = executionTime + actualQueryExecutionTime
+
+          if (stringActual == expected) {
+            PassResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime)
+          } else {
+            FailureResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, s"assert-string-value: expected='$expected', actual='$stringActual'")
+          }
+      }
+    }
   }
 
   /**
-    * Handles the XQTS {@code assert-type} assertion.
-    *
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expectedType the XQTS description of the expected XDM type.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-type} assertion.
+   *
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expectedType    the XQTS description of the expected XDM type.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertType(testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedType: String, actual: ExistServer.QueryResult): TestResult = {
     def getTypes(seq: Sequence): Seq[Int] = {
       for (i <- (0 until seq.getItemCount))
         yield seq.itemAt(i).getType
     }
 
-    def matchCardinality(expectedType: ExistTypeDescription, count: Int) : Boolean = {
+    def matchCardinality(expectedType: ExistTypeDescription, count: Int): Boolean = {
       expectedType match {
         case WildcardExistTypeDescription =>
           true
@@ -1164,7 +1123,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
       }
     }
 
-    def matchType(expectedType: ExistTypeDescription, actualTypes: Seq[Int]) : Boolean = {
+    def matchType(expectedType: ExistTypeDescription, actualTypes: Seq[Int]): Boolean = {
       if (expectedType.hasParameterTypes) {
         logger.warn("assert-type has parameter types, but eXist-db does not correctly support parameter types. Ignoring parameter types. NOTE: this may lead to false positives in test results!")
       }
@@ -1209,19 +1168,17 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Handles the XQTS {@code assert-xml} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expectedXml the XML that is expected as the result of the XQuery.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code assert-xml} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expectedXml     the XML that is expected as the result of the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def assertXml(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedXml: Either[String, Path], @unused ignorePrefixes: Boolean, actual: ExistServer.QueryResult): TestResult = {
     expectedXml.map(readTextFile(_)).fold(Right(_), r => r) match {
       case Left(t) =>
@@ -1238,13 +1195,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
             We first have to serialize the expectedXml just as XQuery would do with
             serialization parameters: method="xml" indent="no" omit-xml-declaration="yes"
             */
-            val expectedQuery = s"""
-                                   | $QUERY_DEFAULT_SERIALIZATION
-                                   |
-                                   | declare variable $$expected as document-node(element($IGNORABLE_WRAPPER_ELEM_NAME)) external;
-                                   |
-                                   | fn:serialize($$expected/$IGNORABLE_WRAPPER_ELEM_NAME/child::node(), $$local:default-serialization)
-                                   |""".stripMargin
+            val expectedQuery =
+              s"""
+                 | $QUERY_DEFAULT_SERIALIZATION
+                 |
+                 | declare variable $$expected as document-node(element($IGNORABLE_WRAPPER_ELEM_NAME)) external;
+                 |
+                 | fn:serialize($$expected/$IGNORABLE_WRAPPER_ELEM_NAME/child::node(), $$local:default-serialization)
+                 |""".stripMargin
 
             connection.executeQuery(expectedQuery, true, None, None, Seq.empty, Seq.empty, Seq.empty, Seq.empty, externalVariables = Seq(EXPECTED_VARIABLE_NAME -> expectedXmlDoc)) match {
               case Left(existServerException) =>
@@ -1253,7 +1211,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
               case Right(Result(Left(queryError), errExpectedCompilationTime, errExpectedExecutionTime)) =>
                 ErrorResult(testSetName, testCaseName, compilationTime + errExpectedCompilationTime, executionTime + errExpectedExecutionTime, new IllegalStateException(s"Error whilst executing XQuery for serializing expected value: ${queryError.errorCode}: ${queryError.message}"))
 
-              case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) if(!allAreStrings(expectedQueryResult)) =>
+              case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) if (!allAreStrings(expectedQueryResult)) =>
                 ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime, executionTime + expectedQueryExecutionTime, new IllegalStateException(s"Test case did not define nodes in assert-xml, expected (after serialization) was: ${connection.sequenceToStringAdaptive(expectedQueryResult)}"))
 
               case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) =>
@@ -1267,7 +1225,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                   case Right(Result(Left(queryError), errActualCompilationTime, errActualExecutionTime)) =>
                     ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + errActualCompilationTime, executionTime + expectedQueryExecutionTime + errActualExecutionTime, new IllegalStateException(s"Error whilst XQuery serializing actual value: ${queryError.errorCode}: ${queryError.message}"))
 
-                  case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) if(!allAreStrings(actualQueryResult)) =>
+                  case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) if (!allAreStrings(actualQueryResult)) =>
                     ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + actualQueryCompilationTime, expectedQueryExecutionTime + actualQueryExecutionTime, new IllegalStateException(s"Test case did not produce nodes in assert-xml, actual (after serialization) was: ${connection.sequenceToStringAdaptive(actualQueryResult)}"))
 
                   case Right(Result(Right(actualQueryResult), actualQueryCompilationTime, actualQueryExecutionTime)) =>
@@ -1277,14 +1235,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                     try {
                       val strActualResult = actualQueryResult.itemAt(0).asInstanceOf[StringValue].getStringValue();
 
-                      val itemIdxs =  (0 until expectedQueryResult.getItemCount)
-                      val differences : Either[XMLUnitException, Seq[String]] = itemIdxs.foldLeft(Either.right[XMLUnitException, Seq[String]](Seq.empty[String]))((accum, itemIdx) => {
+                      val itemIdxs = (0 until expectedQueryResult.getItemCount)
+                      val differences: Either[XMLUnitException, Seq[String]] = itemIdxs.foldLeft(Either.right[XMLUnitException, Seq[String]](Seq.empty[String]))((accum, itemIdx) => {
                         accum match {
-                            // if we have an error don't process anything else, just perpetuate the error
-                          case error @ Left(_) =>
+                          // if we have an error don't process anything else, just perpetuate the error
+                          case error@Left(_) =>
                             error
 
-                          case current @ Right(results) =>
+                          case current@Right(results) =>
                             val strExpectedResult = expectedQueryResult.itemAt(itemIdx).asInstanceOf[StringValue].getStringValue
                             val differences = findDifferences(strExpectedResult, strActualResult)
                             differences match {
@@ -1313,40 +1271,39 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                       }
                     } catch {
                       // TODO(AR) temp try/catch for NPE due to a problem with XmlDiff and eXist-db's DOM(s)?
-                      case npe : NullPointerException =>
+                      case npe: NullPointerException =>
                         ErrorResult(testSetName, testCaseName, totalCompilationTime, totalExecutionTime, npe)
                     }
                 }
             }
-          }
+        }
     }
   }
 
   /**
-    * Handles the XQTS {@code serialization-matches} assertion.
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param testSetName the name of the test-set of which the test-case is a part.
-    * @param testCaseName the name of the test-case which was executed.
-    * @param compilationTime the time taken to compile the XQuery.
-    * @param executionTime the time taken to execute the XQuery.
-    *
-    * @param expected the regular expression that should match the serialialized result of the XQuery.
-    * @param actual the actual result from executing the XQuery.
-    *
-    * @return the test result from processing the assertion.
-    */
+   * Handles the XQTS {@code serialization-matches} assertion.
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param testSetName     the name of the test-set of which the test-case is a part.
+   * @param testCaseName    the name of the test-case which was executed.
+   * @param compilationTime the time taken to compile the XQuery.
+   * @param executionTime   the time taken to execute the XQuery.
+   * @param expected        the regular expression that should match the serialialized result of the XQuery.
+   * @param actual          the actual result from executing the XQuery.
+   * @return the test result from processing the assertion.
+   */
   private def serializationMatches(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: Either[String, Path], flags: Option[String], actual: ExistServer.QueryResult): TestResult = {
     expected.map(readTextFile(_)).fold(Right(_), r => r) match {
       case Left(t) =>
         ErrorResult(testSetName, testCaseName, compilationTime, executionTime, t)
 
       case Right(expectedRegexStr) =>
-        val expectedQuery = s"""
-                               | declare variable $$result external;
-                               |
-                               | fn:matches($$result, ``[$expectedRegexStr]``, "${flags.getOrElse("")}")
-                               |""".stripMargin
+        val expectedQuery =
+          s"""
+             | declare variable $$result external;
+             |
+             | fn:matches($$result, ``[$expectedRegexStr]``, "${flags.getOrElse("")}")
+             |""".stripMargin
         val actualStr = connection.sequenceToString(actual)
         executeQueryWith$Result(connection, expectedQuery, true, None, new StringValue(actualStr)) match {
           case Left(existServerException) =>
@@ -1370,14 +1327,13 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Finds the differences between two XML documents
-    *
-    * @param expected the expected XML document.
-    * @param actual the actual XML document.
-    *
-    * @return Some string describing the differences, or None of there are no differences.
-    */
-  private def findDifferences(expected : String, actual: String) : Either[XMLUnitException, Option[String]] = {
+   * Finds the differences between two XML documents
+   *
+   * @param expected the expected XML document.
+   * @param actual   the actual XML document.
+   * @return Some string describing the differences, or None of there are no differences.
+   */
+  private def findDifferences(expected: String, actual: String): Either[XMLUnitException, Option[String]] = {
     try {
       val expectedSource = Input.fromString(s"<$IGNORABLE_WRAPPER_ELEM_NAME>$expected</$IGNORABLE_WRAPPER_ELEM_NAME>").build()
       val actualSource = Input.fromString(s"<$IGNORABLE_WRAPPER_ELEM_NAME>$actual</$IGNORABLE_WRAPPER_ELEM_NAME>").build()
@@ -1400,46 +1356,43 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Returns true if all items in the sequence are Nodes.
-    *
-    * @param sequence the sequence to test.
-    *
-    * @return true if all sequence items are nodes, false otherwise.
-    */
+   * Returns true if all items in the sequence are Nodes.
+   *
+   * @param sequence the sequence to test.
+   * @return true if all sequence items are nodes, false otherwise.
+   */
   @unused
-  private def allAreNodes(sequence: Sequence) : Boolean = {
+  private def allAreNodes(sequence: Sequence): Boolean = {
     val types = for (i <- (0 until sequence.getItemCount))
       yield sequence.itemAt(i).getType
     types.filterNot(Type.subTypeOf(_, Type.NODE)).isEmpty
   }
 
   /**
-    * Returns true if all items in the sequence are Strings.
-    *
-    * @param sequence the sequence to test.
-    *
-    * @return true if all sequence items are strings, false otherwise.
-    */
-  private def allAreStrings(sequence: Sequence) : Boolean = {
+   * Returns true if all items in the sequence are Strings.
+   *
+   * @param sequence the sequence to test.
+   * @return true if all sequence items are strings, false otherwise.
+   */
+  private def allAreStrings(sequence: Sequence): Boolean = {
     val types = for (i <- (0 until sequence.getItemCount))
       yield sequence.itemAt(i).getType
     types.filterNot(Type.subTypeOf(_, Type.STRING)).isEmpty
   }
 
   /**
-    * Reads the content of a text file.
-    *
-    * NOTE: this function does not use any caching, and
-    * should only be used where resources will not be used
-    * repeatedly. If you want caching, you should instead
-    * use the {@link CommonResourceCacheActor}.
-    *
-    * @param path the path to the file.
-    * @param charset the character encoding of the file; Defaults to UTF-8.
-    *
-    * @return the content of the file as a string, or an exception.
-    */
-  private def readTextFile(path: Path, charset: Charset = UTF_8) : Either[IOException, String] = {
+   * Reads the content of a text file.
+   *
+   * NOTE: this function does not use any caching, and
+   * should only be used where resources will not be used
+   * repeatedly. If you want caching, you should instead
+   * use the [[CommonResourceCacheActor]].
+   *
+   * @param path    the path to the file.
+   * @param charset the character encoding of the file; Defaults to UTF-8.
+   * @return the content of the file as a string, or an exception.
+   */
+  private def readTextFile(path: Path, charset: Charset = UTF_8): Either[IOException, String] = {
     val fileIO = IO.blocking {
       Either.catchOnly[IOException](new String(Files.readAllBytes(path), charset))
     }
@@ -1449,50 +1402,47 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-    * Executes an XQuery where the external
-    * variable {@code $result} is bound to a provided
-    * sequence (typically the result of a previous
-    * query execution).
-    *
-    * @param connection a connection to an eXist-db server.
-    * @param query the XQuery to execute.
-    * @param cacheCompiled true if the compiled form of the XQuery should be cached.
-    * @param contextSequence an optional context sequence for the XQuery to operate on.
-    * @param $result the sequence to be bound to the {@code $result} variable.
-    *
-    * @return the result or executing the query, or an exception.
-    */
+   * Executes an XQuery where the external
+   * variable <pre>$result</pre> is bound to a provided
+   * sequence (typically the result of a previous
+   * query execution).
+   *
+   * @param connection      a connection to an eXist-db server.
+   * @param query           the XQuery to execute.
+   * @param cacheCompiled   true if the compiled form of the XQuery should be cached.
+   * @param contextSequence an optional context sequence for the XQuery to operate on.
+   * @param $result         the sequence to be bound to the  <pre>$result</pre>  variable.
+   * @return the result or executing the query, or an exception.
+   */
   private def executeQueryWith$Result(connection: ExistConnection, query: String, cacheCompiled: Boolean, contextSequence: Option[Sequence], $result: Sequence) = {
     connection.executeQuery(query, cacheCompiled, None, contextSequence, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq(RESULT_VARIABLE_NAME -> $result))
   }
 
   /**
-    * Formats a failure message.
-    *
-    * @param expectedResult the expected result.
-    * @param actual the actual result.
-    *
-    * @return the formatted failure message.
-    */
+   * Formats a failure message.
+   *
+   * @param expectedResult the expected result.
+   * @param actual         the actual result.
+   * @return the formatted failure message.
+   */
   private def failureMessage(expectedResult: XQTSParserActor.Result, actual: QueryError): String = {
     s"Expected: '$expectedResult', but query returned an error: $actual"
   }
 
   /**
-    * Formats a failure message.
-    *
-    * @param connection a connection to an eXist-db server; Used for serialization of the actual results.
-    * @param expectedResult the expected result.
-    * @param actual the actual result.
-    *
-    * @return the formatted failure message.
-    */
+   * Formats a failure message.
+   *
+   * @param connection     a connection to an eXist-db server; Used for serialization of the actual results.
+   * @param expectedResult the expected result.
+   * @param actual         the actual result.
+   * @return the formatted failure message.
+   */
   private def failureMessage(connection: ExistConnection)(expectedResult: XQTSParserActor.Result, actual: ExistServer.QueryResult): String = {
     try {
       s"Expected: '$expectedResult', but query returned: '${connection.sequenceToStringAdaptive(actual)}'"
     } catch {
       // TODO(AR) temp try/catch for NPE due to a problem with OrderedValueSequence.toString
-      case npe : NullPointerException =>
+      case npe: NullPointerException =>
         npe.toString
     }
   }
@@ -1504,55 +1454,67 @@ object TestCaseRunnerActor {
   private case class RunTestCaseInternal(runTestCase: RunTestCase, resolvedEnvironment: ResolvedEnvironment)
 
   /**
-    * The result of executing an XQTS test-case.
-    */
+   * The result of executing an XQTS test-case.
+   */
   sealed trait TestResult {
     def testSet: String
+
     def testCase: String
+
     def compilationTime: CompilationTime
+
     def executionTime: ExecutionTime
   }
+
   case class PassResult(testSet: String, testCase: String, compilationTime: CompilationTime, executionTime: ExecutionTime) extends TestResult
+
   case class AssumptionFailedResult(testSet: String, testCase: String, compilationTime: CompilationTime, executionTime: ExecutionTime, reason: String) extends TestResult
+
   case class FailureResult(testSet: String, testCase: String, compilationTime: CompilationTime, executionTime: ExecutionTime, reason: String) extends TestResult
+
   case class ErrorResult(testSet: String, testCase: String, compilationTime: CompilationTime, executionTime: ExecutionTime, t: Throwable) extends TestResult
 
   private val EXPECTED_VARIABLE_NAME = "expected"
   private val RESULT_VARIABLE_NAME = "result"
-  private val QUERY_NORMALIZED_SPACE = s"""
-                                       | declare variable $$result external;
-                                       |
-                                       | normalize-space($$result)
-                                       |""".stripMargin
-  private val QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE = s"""
-                                                           | declare variable $$result external;
-                                                           |
-                                                           | normalize-space(string-join(for $$r in $$result return string($$r), " "))
-                                                           |""".stripMargin
-  private val QUERY_ASSERT_STRING_VALUE = s"""
-                                             | declare variable $$result external;
-                                             |
-                                             | string-join(for $$r in $$result return string($$r), " ")
-                                             |""".stripMargin
-  private val QUERY_DEFAULT_SERIALIZATION = """
-                                              |xquery version "3.1";
-                                              |declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
-                                              |
-                                              |declare variable $local:default-serialization :=
-                                              |  <output:serialization-parameters>
-                                              |    <output:method value="xml"/>
-                                              |    <output:indent value="no"/>
-                                              |    <output:omit-xml-declaration value="yes"/>
-                                              |  </output:serialization-parameters>;
-                                              |
-                                              |""".stripMargin
-  private val QUERY_ASSERT_XML_SERIALIZATION = s"""
-                                                  | $QUERY_DEFAULT_SERIALIZATION
-                                                  |
-                                                  | declare variable $$result external;
-                                                  |
-                                                  | fn:serialize($$result, $$local:default-serialization)
-                                                  |""".stripMargin
+  private val QUERY_NORMALIZED_SPACE =
+    s"""
+       | declare variable $$result external;
+       |
+       | normalize-space($$result)
+       |""".stripMargin
+  private val QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE =
+    s"""
+       | declare variable $$result external;
+       |
+       | normalize-space(string-join(for $$r in $$result return string($$r), " "))
+       |""".stripMargin
+  private val QUERY_ASSERT_STRING_VALUE =
+    s"""
+       | declare variable $$result external;
+       |
+       | string-join(for $$r in $$result return string($$r), " ")
+       |""".stripMargin
+  private val QUERY_DEFAULT_SERIALIZATION =
+    """
+      |xquery version "3.1";
+      |declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+      |
+      |declare variable $local:default-serialization :=
+      |  <output:serialization-parameters>
+      |    <output:method value="xml"/>
+      |    <output:indent value="no"/>
+      |    <output:omit-xml-declaration value="yes"/>
+      |  </output:serialization-parameters>;
+      |
+      |""".stripMargin
+  private val QUERY_ASSERT_XML_SERIALIZATION =
+    s"""
+       | $QUERY_DEFAULT_SERIALIZATION
+       |
+       | declare variable $$result external;
+       |
+       | fn:serialize($$result, $$local:default-serialization)
+       |""".stripMargin
 
   private lazy val ignorableWrapperComparisonFormatter = new IgnorableWrapperComparisonFormatter()
 
@@ -1560,22 +1522,26 @@ object TestCaseRunnerActor {
    Resolved Environment resources
    */
   case class ResolvedSchema(path: Path, data: Array[Byte])
+
   case class ResolvedSource(path: Path, data: Array[Byte])
+
   case class ResolvedResource(path: Path, data: Array[Byte])
+
   case class ResolvedEnvironment(resolvedSchemas: Seq[ResolvedSchema] = Seq.empty, resolvedSources: Seq[ResolvedSource] = Seq.empty, resolvedResources: Seq[ResolvedResource] = Seq.empty, resolvedQuery: Option[String] = None)
+
   case class PendingTestCase(runTestCase: RunTestCase, resolvedEnvironment: ResolvedEnvironment)
 
-  private def merge(existing: Map[Path, Seq[TestCaseId]])(id: TestCaseId, additions: List[() => Path]) : Map[Path, Seq[TestCaseId]] = {
-    additions.foldLeft(existing){(accum, x) =>
+  private def merge(existing: Map[Path, Seq[TestCaseId]])(id: TestCaseId, additions: List[() => Path]): Map[Path, Seq[TestCaseId]] = {
+    additions.foldLeft(existing) { (accum, x) =>
       accum + (x() -> (accum.get(x()).getOrElse(Seq.empty) :+ id))
     }
   }
 
-  private def merge1(existing: Map[Path, Seq[TestCaseId]])(id: TestCaseId, addition: Path) : Map[Path, Seq[TestCaseId]] = {
+  private def merge1(existing: Map[Path, Seq[TestCaseId]])(id: TestCaseId, addition: Path): Map[Path, Seq[TestCaseId]] = {
     existing + (addition -> (existing.get(addition).getOrElse(Seq.empty) :+ id))
   }
 
-  private def addIfNotPresent(existing: Map[TestCaseId, PendingTestCase])(runTestCase: RunTestCase) : Map[TestCaseId, PendingTestCase] = {
+  private def addIfNotPresent(existing: Map[TestCaseId, PendingTestCase])(runTestCase: RunTestCase): Map[TestCaseId, PendingTestCase] = {
     val testCaseId = (runTestCase.testSetRef.name, runTestCase.testCase.name)
     existing.get(testCaseId) match {
       case Some(_) => existing
@@ -1583,35 +1549,35 @@ object TestCaseRunnerActor {
     }
   }
 
-  private def addSchemas(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]) : Map[TestCaseId, PendingTestCase] = {
-    testCases.foldLeft(pending){(accum, x) =>
+  private def addSchemas(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]): Map[TestCaseId, PendingTestCase] = {
+    testCases.foldLeft(pending) { (accum, x) =>
       val pendingTestCase = accum(x)
       accum + (x -> pendingTestCase.copy(resolvedEnvironment = pendingTestCase.resolvedEnvironment.copy(resolvedSchemas = pendingTestCase.resolvedEnvironment.resolvedSchemas :+ ResolvedSchema(path, value))))
     }
   }
 
-  private def addSources(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]) : Map[TestCaseId, PendingTestCase] = {
-    testCases.foldLeft(pending){(accum, x) =>
+  private def addSources(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]): Map[TestCaseId, PendingTestCase] = {
+    testCases.foldLeft(pending) { (accum, x) =>
       val pendingTestCase = accum(x)
       accum + (x -> pendingTestCase.copy(resolvedEnvironment = pendingTestCase.resolvedEnvironment.copy(resolvedSources = pendingTestCase.resolvedEnvironment.resolvedSources :+ ResolvedSource(path, value))))
     }
   }
 
-  private def addResources(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]) : Map[TestCaseId, PendingTestCase] = {
-    testCases.foldLeft(pending){(accum, x) =>
+  private def addResources(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], path: Path, value: Array[Byte]): Map[TestCaseId, PendingTestCase] = {
+    testCases.foldLeft(pending) { (accum, x) =>
       val pendingTestCase = accum(x)
       accum + (x -> pendingTestCase.copy(resolvedEnvironment = pendingTestCase.resolvedEnvironment.copy(resolvedResources = pendingTestCase.resolvedEnvironment.resolvedResources :+ ResolvedResource(path, value))))
     }
   }
 
-  private def addQueryStrs(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], @unused path: Path, value: Array[Byte]) : Map[TestCaseId, PendingTestCase] = {
-    testCases.foldLeft(pending){(accum, x) =>
+  private def addQueryStrs(pending: Map[TestCaseId, PendingTestCase])(testCases: Seq[TestCaseId], @unused path: Path, value: Array[Byte]): Map[TestCaseId, PendingTestCase] = {
+    testCases.foldLeft(pending) { (accum, x) =>
       val pendingTestCase = accum(x)
       accum + (x -> pendingTestCase.copy(resolvedEnvironment = pendingTestCase.resolvedEnvironment.copy(resolvedQuery = Some(new String(value, UTF_8)))))
     }
   }
 
-  private def notIn(existing: Map[Path, Seq[TestCaseId]])(testCase: TestCaseId) : Boolean = {
+  private def notIn(existing: Map[Path, Seq[TestCaseId]])(testCase: TestCaseId): Boolean = {
     !existing.values.flatten.toSeq.contains(testCase)
   }
 }
@@ -1622,12 +1588,12 @@ private object IgnorableWrapper {
 }
 
 /**
-  * Exactly the same as {@link DefaultComparisonFormatter#getDescription(Comparison)}
-  * except that we drop the leading "/ignorable-wrapper" from the XPath.
-  */
+ * Exactly the same as [[DefaultComparisonFormatter# getDescription ( Comparison )]]
+ * except that we drop the leading "/ignorable-wrapper" from the XPath.
+ */
 private class IgnorableWrapperComparisonFormatter extends DefaultComparisonFormatter {
 
-  private def abbridgeXPath(xpath: String) : String = {
+  private def abbridgeXPath(xpath: String): String = {
     val matcher = IGNORABLE_WRAPPER_XPATH_PREFIX.matcher(xpath)
     matcher.replaceFirst("") match {
       case empty if empty.isEmpty => "/"

--- a/src/main/scala/org/exist/xqts/runner/Unzip.scala
+++ b/src/main/scala/org/exist/xqts/runner/Unzip.scala
@@ -27,20 +27,19 @@ import cats.effect.{IO, Resource}
 import scala.annotation.tailrec
 
 /**
-  * Small functions for unzipping data.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Small functions for unzipping data.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object Unzip {
 
   /**
-    * Unzip a file to a directory.
-    *
-    * @param src the zip file.
-    * @param dir the directory to unzip the {@code src} file into.
-    *
-    * @throws IOException if an error occurs whilst unzipping the {@code src} file.
-    */
+   * Unzip a file to a directory.
+   *
+   * @param src the zip file.
+   * @param dir the directory to unzip the {@code src} file into.
+   * @throws IOException if an error occurs whilst unzipping the {@code src} file.
+   */
   @throws[IOException]
   def unzip(src: Path, dir: Path): Unit = {
 
@@ -54,7 +53,7 @@ object Unzip {
         val buffer = new Array[Byte](4096)
         copy(buffer)(zipInputStream, os.get)
       } finally {
-          os.map(_.close())
+        os.map(_.close())
       }
     }
 
@@ -85,11 +84,19 @@ object Unzip {
     }
 
 
-    val unzipIO : IO[Unit] =
+    val unzipIO: IO[Unit] =
       Resource
-        .make(IO { Files.newInputStream(src)} )(fis => IO { fis.close() })
+        .make(IO {
+          Files.newInputStream(src)
+        })(fis => IO {
+          fis.close()
+        })
         .use { fis =>
-          Resource.make(IO { new ZipInputStream(fis) })(zis => IO { zis.close() })
+          Resource.make(IO {
+              new ZipInputStream(fis)
+            })(zis => IO {
+              zis.close()
+            })
             .use { zis =>
               IO {
                 processEntries(zis)(writeZipEntry(zis, _))

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -33,21 +33,22 @@ import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
 import scala.annotation.unused
 
 /**
-  * An initial Actor that parses
-  * an XQTS.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * An initial Actor that parses
+ * an XQTS.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 trait XQTSParserActor extends Actor {
 }
 
 /**
-  * Objects and Classes that are used for parsing an XQTS.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Objects and Classes that are used for parsing an XQTS.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object XQTSParserActor {
   case class Parse(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], testSets: Either[Set[String], Pattern], testCases: Either[Set[String], Pattern], excludeTestSets: Set[String], excludeTestCases: Set[String])
+
   case class ParseComplete(xqtsVersion: XQTSVersion, xqtsPath: Path, matchedTestSets: Int)
 
   object Validation extends Enumeration {
@@ -56,7 +57,7 @@ object XQTSParserActor {
   }
 
   object Role {
-    def parse(role : String) : Role = {
+    def parse(role: String): Role = {
       role match {
         case "." => ContextItemRole
         case _ if role.charAt(0).equals('$') => ExternalVariableRole(role.substring(1))
@@ -68,22 +69,34 @@ object XQTSParserActor {
       role == ContextItemRole
     }
   }
+
   sealed abstract class Role
+
   case object ContextItemRole extends Role
+
   case class ExternalVariableRole(name: String) extends Role
 
 
   case class Environment(name: String, schemas: List[Schema] = List.empty, sources: List[Source] = List.empty, resources: List[Resource] = List.empty, params: List[Param] = List.empty, contextItem: Option[String] = None, decimalFormats: List[DecimalFormat] = List.empty, namespaces: List[Namespace] = List.empty, collections: List[Collection] = List.empty, staticBaseUri: Option[String] = None, collation: Option[Collation] = None)
+
   case class Schema(uri: Option[AnyURIValue], file: Option[Path], xsdVersion: Float = 1.0f, description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
+
   case class Source(role: Option[Role], file: Path, uri: Option[String], validation: Option[Validation.Validation] = None, description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
+
   case class Resource(file: Path, uri: String, mediaType: Option[String] = None, encoding: Option[String], description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
+
   case class Param(name: String, select: Option[String] = None, as: Option[String] = None, source: Option[String] = None, declared: Boolean = false)
+
   case class DecimalFormat(name: Option[QName] = None, decimalSeparator: Option[Int] = None, exponentSeparator: Option[Int] = None, groupingSeparator: Option[Int] = None, zeroDigit: Option[Int] = None, digit: Option[Int] = None, minusSign: Option[Int] = None, percent: Option[Int] = None, perMille: Option[Int] = None, patternSeparator: Option[Int] = None, infinity: Option[String] = None, notANumber: Option[String] = None)
+
   case class Namespace(prefix: String, uri: URI)
+
   case class Collection(uri: AnyURIValue, sources: List[Source] = List.empty)
+
   case class Collation(uri: URI, default: Boolean = false)
 
   case class Created(by: String, on: String)
+
   case class Modified(by: String, on: String, change: String)
 
   case class TestSetRef(xqtsVersion: XQTSVersion, name: String, file: Path)
@@ -93,57 +106,85 @@ object XQTSParserActor {
   type TestCaseId = (TestSetName, TestCaseName)
 
   case class TestSet(name: TestSetName, covers: String, description: Option[String] = None, links: Seq[Link] = List.empty, dependencies: Seq[Dependency] = Seq.empty, testCases: Seq[TestCase] = Seq.empty)
+
   case class Link(`type`: String, document: String, section: Option[String] = None)
+
   case class Module(uri: AnyURIValue, file: Path)
+
   case class Dependency(`type`: DependencyType, value: String, satisfied: Boolean)
+
   case class TestCase(file: Path, name: TestCaseName, covers: String, description: Option[String] = None, created: Option[Created] = None, modifications: Seq[Modified] = Seq.empty, environment: Option[Environment] = None, modules: Seq[Module] = Seq.empty, dependencies: Seq[Dependency] = Seq.empty, test: Option[Either[String, Path]] = None, result: Option[Result] = None)
+
   sealed trait Result
 
   /*
    XQTS Assertions
   */
   sealed trait Assertion extends Result
+
   sealed trait Assertions extends Result {
     def assertions: List[Result]
-    def :+(assertion: Result) : Assertions
+
+    def :+(assertion: Result): Assertions
   }
+
   case class AllOf(assertions: List[Result]) extends Assertions {
-    override def :+(assertion: Result) : AllOf = this.copy(assertions = this.assertions :+ assertion)
+    override def :+(assertion: Result): AllOf = this.copy(assertions = this.assertions :+ assertion)
   }
+
   case class AnyOf(assertions: List[Result]) extends Assertions {
-    override def :+(assertion: Result) : AnyOf = this.copy(assertions = this.assertions :+ assertion)
+    override def :+(assertion: Result): AnyOf = this.copy(assertions = this.assertions :+ assertion)
   }
+
   case class Not(assertion: Option[Result] = None) extends Assertion
+
   sealed trait ValueAssertion[T] extends Assertion {
     def expected: T
   }
+
   case class Assert(expected: String) extends ValueAssertion[String]
+
   case class AssertCount(expected: Int) extends ValueAssertion[Int]
+
   case class AssertDeepEquals(expected: String) extends ValueAssertion[String]
+
   case class AssertEq(expected: String) extends ValueAssertion[String]
+
   case class AssertPermutation(expected: String) extends ValueAssertion[String]
+
   case class AssertSerializationError(expected: String) extends ValueAssertion[String]
+
   case class AssertStringValue(value: String, normalizeSpace: Boolean) extends Assertion
+
   case class AssertType(expected: String) extends ValueAssertion[String]
+
   case class AssertXml(expected: Either[String, Path], ignorePrefixes: Boolean = false) extends ValueAssertion[Either[String, Path]]
+
   case class SerializationMatches(expected: Either[String, Path], flags: Option[String] = None) extends ValueAssertion[Either[String, Path]]
+
   case object AssertEmpty extends Assertion
+
   case object AssertTrue extends Assertion
+
   case object AssertFalse extends Assertion
+
   case class Error(expected: String) extends ValueAssertion[String]
 
   /**
-    * Enumeration of XQTS dependency types.
-    */
+   * Enumeration of XQTS dependency types.
+   */
   object DependencyType extends Enumeration {
+
     import scala.language.implicitConversions
 
     protected case class DependencyTypeVal(xqtsName: String) extends super.Val
+
     implicit def valueToDependencyTypeVal(x: Value): DependencyTypeVal = x.asInstanceOf[DependencyTypeVal]
+
     type DependencyType = DependencyTypeVal
 
     @throws[IllegalArgumentException]
-    def fromXqtsName(xqtsName: String) : DependencyType = {
+    def fromXqtsName(xqtsName: String): DependencyType = {
       this.values.find(_.xqtsName == xqtsName) match {
         case Some(dependencyType) => dependencyType
         case None => throw new IllegalArgumentException(s"No dependency type with XQTS name: $xqtsName")
@@ -167,30 +208,29 @@ object XQTSParserActor {
   }
 
   /**
-    * Enumeration of XQTS dependency spec values.
-    */
+   * Enumeration of XQTS dependency spec values.
+   */
   object Spec extends Enumeration {
     type Spec = Value
     val XP10, XP20, XP30, XP31, XQ10, XQ30, XQ31, XT30 = Value
 
     /**
-      * Returns all specs which implement at
-      * least {@code spec}.
-      *
-      * @param spec the least spec.
-      *
-      * @return all specs that implement at least {@code spec}.
-      */
-    def atLeast(spec: Spec) : Set[Spec] = {
+     * Returns all specs which implement at
+     * least {@code spec}.
+     *
+     * @param spec the least spec.
+     * @return all specs that implement at least {@code spec}.
+     */
+    def atLeast(spec: Spec): Set[Spec] = {
       spec match {
         case XP10 =>
           Set(XP10, XP20, XP30, XP31)
         case XP20 =>
           Set(XP20, XP30, XP31)
         case XP30 =>
-          Set (XP30, XP31)
+          Set(XP30, XP31)
         case XP31 =>
-          Set (XP31)
+          Set(XP31)
 
         case XQ10 =>
           Set(XQ10, XQ30, XQ31)
@@ -206,17 +246,20 @@ object XQTSParserActor {
   }
 
   /**
-    * Enumeration of XQTS dependency feature values.
-    */
+   * Enumeration of XQTS dependency feature values.
+   */
   object Feature extends Enumeration {
+
     import scala.language.implicitConversions
 
     protected case class FeatureVal(xqtsName: String) extends super.Val
+
     implicit def valueToFeatureVal(x: Value): FeatureVal = x.asInstanceOf[FeatureVal]
+
     type Feature = FeatureVal
 
     @throws[IllegalArgumentException]
-    def fromXqtsName(xqtsName: String) : Feature = {
+    def fromXqtsName(xqtsName: String): Feature = {
       this.values.find(_.xqtsName == xqtsName) match {
         case Some(feature) => feature
         case None => throw new IllegalArgumentException(s"No feature with XQTS name: $xqtsName")
@@ -242,13 +285,16 @@ object XQTSParserActor {
   }
 
   /**
-    * Enumeration of XQTS dependency xsd-version values.
-    */
+   * Enumeration of XQTS dependency xsd-version values.
+   */
   object XsdVersion extends Enumeration {
+
     import scala.language.implicitConversions
 
     protected case class XsdVersionVal(xqtsName: String) extends super.Val
+
     implicit def valueToXsdVersionVal(x: Value): XsdVersionVal = x.asInstanceOf[XsdVersionVal]
+
     type XsdVersion = XsdVersionVal
 
     @throws[IllegalArgumentException]
@@ -264,13 +310,16 @@ object XQTSParserActor {
   }
 
   /**
-    * Enumeration of XQTS dependency xml-version values.
-    */
+   * Enumeration of XQTS dependency xml-version values.
+   */
   object XmlVersion extends Enumeration {
+
     import scala.language.implicitConversions
 
     protected case class XmlVersionVal(xqtsName: String) extends super.Val
+
     implicit def valueToXmlVersionVal(x: Value): XmlVersionVal = x.asInstanceOf[XmlVersionVal]
+
     type XmlVersion = XmlVersionVal
 
     @throws[IllegalArgumentException]
@@ -287,13 +336,13 @@ object XQTSParserActor {
     val XML11 = XmlVersionVal("1.1")
 
     /**
-      * Given a base version,
-      * returns all compatible versions.
-      *
-      * @param base the base versions
-      * @return the compatible versions
-      */
-    def compatible(base: XmlVersion) : Set[XmlVersion] = {
+     * Given a base version,
+     * returns all compatible versions.
+     *
+     * @param base the base versions
+     * @return the compatible versions
+     */
+    def compatible(base: XmlVersion): Set[XmlVersion] = {
       base match {
         case XML10_4thOrEarlier =>
           Set(XML10_4thOrEarlier)
@@ -316,37 +365,37 @@ object XQTSParserActor {
   type Missing = Seq[String]
 
   /**
-    * Checks for missing dependencies.
-    *
-    * @param required The required dependencies.
-    * @param enabledFeatures The features which are enabled.
-    * @param enabledSpecs The specifications which are enabled.
-    * @param enabledXmlVersions The XML versions which are enabled.
-    * @param enabledXsdVersions The XSD versions which are enabled.
-    *
-    * @return A list of all missing dependencies, or an empty list
-    *         if there are no missing depdencies.
-    */
-  def missingDependencies(required: Seq[Dependency], enabledFeatures: Set[Feature], enabledSpecs: Set[Spec], enabledXmlVersions: Set[XmlVersion], enabledXsdVersions: Set[XsdVersion]) : Missing = {
+   * Checks for missing dependencies.
+   *
+   * @param required           The required dependencies.
+   * @param enabledFeatures    The features which are enabled.
+   * @param enabledSpecs       The specifications which are enabled.
+   * @param enabledXmlVersions The XML versions which are enabled.
+   * @param enabledXsdVersions The XSD versions which are enabled.
+   * @return A list of all missing dependencies, or an empty list
+   *         if there are no missing depdencies.
+   */
+  def missingDependencies(required: Seq[Dependency], enabledFeatures: Set[Feature], enabledSpecs: Set[Spec], enabledXmlVersions: Set[XmlVersion], enabledXsdVersions: Set[XsdVersion]): Missing = {
     type Missed = Option[String]
 
-    def hasEnabledFeature(requiredFeature: String) : Missed = {
+    def hasEnabledFeature(requiredFeature: String): Missed = {
       if (enabledFeatures.map(_.xqtsName).contains(requiredFeature)) {
         None
       } else {
-       Some(requiredFeature)
+        Some(requiredFeature)
       }
     }
 
-    def hasEnabledSpec(requiredSpec: String) : Missed = {
-      def lookupSpecs(specStr: String) : Set[Spec] = {
+    def hasEnabledSpec(requiredSpec: String): Missed = {
+      def lookupSpecs(specStr: String): Set[Spec] = {
         if (specStr.endsWith("+")) {
           Spec.atLeast(Spec.withName(specStr.substring(0, specStr.length - 1)))
         } else {
           Set(Spec.withName(specStr))
         }
       }
-      val anyRequiredSpecs : Set[Spec] = requiredSpec.split(' ').toSet.flatMap(lookupSpecs)
+
+      val anyRequiredSpecs: Set[Spec] = requiredSpec.split(' ').toSet.flatMap(lookupSpecs)
       if (anyRequiredSpecs.find(enabledSpecs.contains(_)).nonEmpty) {
         None
       } else {
@@ -354,9 +403,9 @@ object XQTSParserActor {
       }
     }
 
-    def hasEnabledXmlVersion(requiredXmlVersion: String) : Missed = {
+    def hasEnabledXmlVersion(requiredXmlVersion: String): Missed = {
       def check(version: String): Missed = {
-        val compatibleVersions : Set[XmlVersion] = XmlVersion.compatible(XmlVersion.fromXqtsName(version))
+        val compatibleVersions: Set[XmlVersion] = XmlVersion.compatible(XmlVersion.fromXqtsName(version))
         if (compatibleVersions.find(enabledXmlVersions.contains(_)).nonEmpty) {
           None
         } else {
@@ -365,16 +414,16 @@ object XQTSParserActor {
       }
 
       val requiredXmlVersions = requiredXmlVersion.split(' ')
-      requiredXmlVersions.foldLeft(Option.empty[String]){(accum, x) =>
-       accum match {
-         case missing @ Some(_) => missing
-         case None =>
-           check(x)
-       }
+      requiredXmlVersions.foldLeft(Option.empty[String]) { (accum, x) =>
+        accum match {
+          case missing@Some(_) => missing
+          case None =>
+            check(x)
+        }
       }
     }
 
-    def hasEnabledXsdVersion(requiredXsdVersion: String) : Missed = {
+    def hasEnabledXsdVersion(requiredXsdVersion: String): Missed = {
       if (enabledXsdVersions.map(_.xqtsName).contains(requiredXsdVersion)) {
         None
       } else {
@@ -383,13 +432,13 @@ object XQTSParserActor {
     }
 
     @unused
-    def firstMissing(test: String => Missed, required: Seq[Dependency]) : Missed = {
+    def firstMissing(test: String => Missed, required: Seq[Dependency]): Missed = {
       required.foldLeft(Option.empty[String]) { case (accum, x) =>
         accum.orElse(test(x.value))
       }
     }
 
-    def allMissing(test: String => Missed, required: Seq[Dependency]) : Missing = {
+    def allMissing(test: String => Missed, required: Seq[Dependency]): Missing = {
       required.foldLeft(Seq.empty[String]) { case (accum, x) =>
         test(x.value)
           .filter(_ => x.satisfied)
@@ -407,16 +456,16 @@ object XQTSParserActor {
 
     allMissing(hasEnabledFeature, requiredFeatures) ++
       allMissing(hasEnabledSpec, requiredSpecs) ++
-        allMissing(hasEnabledXmlVersion, requiredXmlVersions) ++
-          allMissing(hasEnabledXsdVersion, requiredXsdVersions)
+      allMissing(hasEnabledXmlVersion, requiredXmlVersions) ++
+      allMissing(hasEnabledXsdVersion, requiredXsdVersions)
   }
 }
 
 /**
-  * Exception type for errors that occure during
-  * parsing of XQTS, due to unexpected structure
-  * or values within the XQTS.
-  *
-  * @param message a description of the error.
-  */
+ * Exception type for errors that occure during
+ * parsing of XQTS, due to unexpected structure
+ * or values within the XQTS.
+ *
+ * @param message a description of the error.
+ */
 case class XQTSParseException(message: String) extends Exception(message)

--- a/src/main/scala/org/exist/xqts/runner/XQTSResultsSerializerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSResultsSerializerActor.scala
@@ -22,25 +22,28 @@ import org.exist.xqts.runner.TestCaseRunnerActor.TestResult
 import org.exist.xqts.runner.XQTSParserActor.TestSetRef
 
 /**
-  * An Actor that serializes the
-  * results of executing the tests
-  * within an XQTS.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * An Actor that serializes the
+ * results of executing the tests
+ * within an XQTS.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 trait XQTSResultsSerializerActor extends Actor {
 }
 
 /**
-  * Objects and Classes that are used for serializing the
-  * an results of executing the tests
-  * within an XQTS.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Objects and Classes that are used for serializing the
+ * an results of executing the tests
+ * within an XQTS.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object XQTSResultsSerializerActor {
   case class TestSetResults(testSetRef: TestSetRef, results: Seq[TestResult])
+
   case class SerializedTestSetResults(testSetRef: TestSetRef)
+
   case object FinalizeSerialization
+
   case object FinishedSerialization
 }

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -42,34 +42,34 @@ import scala.language.postfixOps
 import scala.util.Try
 
 /**
-  * This is the Entry Point to the command line XQTS Runner application.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * This is the Entry Point to the command line XQTS Runner application.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object XQTSRunner {
 
   /**
-    * Container for command line options.
-    */
+   * Container for command line options.
+   */
   private case class CmdConfig(
-      xqtsVersion: XQTSVersion = XQTS_3_1,
-      localDir: Option[Path] = None,
-      enableFeatures : Seq[Feature] = Seq.empty,
-      disableFeatures : Seq[Feature] = Seq.empty,
-      enableSpecs: Seq[Spec] = Seq.empty,
-      disableSpecs: Seq[Spec] = Seq.empty,
-      enableXmlVersions: Seq[XmlVersion] = Seq.empty,
-      disableXmlVersions: Seq[XmlVersion] = Seq.empty,
-      enableXsdVersions: Seq[XsdVersion] = Seq.empty,
-      disableXsdVersions: Seq[XsdVersion] = Seq.empty,
-      testSetPattern: Option[Pattern] = None,
-      testSets: Seq[String] = Seq.empty,
-      testCasePattern: Option[Pattern] = None,
-      testCases: Seq[String] = Seq.empty,
-      excludeTestSets: Seq[String] = Seq.empty,
-      excludeTestCases: Seq[String] = Seq.empty,
-      outputDir: Option[Path] = None
-  )
+                                xqtsVersion: XQTSVersion = XQTS_3_1,
+                                localDir: Option[Path] = None,
+                                enableFeatures: Seq[Feature] = Seq.empty,
+                                disableFeatures: Seq[Feature] = Seq.empty,
+                                enableSpecs: Seq[Spec] = Seq.empty,
+                                disableSpecs: Seq[Spec] = Seq.empty,
+                                enableXmlVersions: Seq[XmlVersion] = Seq.empty,
+                                disableXmlVersions: Seq[XmlVersion] = Seq.empty,
+                                enableXsdVersions: Seq[XsdVersion] = Seq.empty,
+                                disableXsdVersions: Seq[XsdVersion] = Seq.empty,
+                                testSetPattern: Option[Pattern] = None,
+                                testSets: Seq[String] = Seq.empty,
+                                testCasePattern: Option[Pattern] = None,
+                                testCases: Seq[String] = Seq.empty,
+                                excludeTestSets: Seq[String] = Seq.empty,
+                                excludeTestCases: Seq[String] = Seq.empty,
+                                outputDir: Option[Path] = None
+                              )
 
   /*
     Exit codes of the application.
@@ -80,8 +80,8 @@ object XQTSRunner {
   private val EXIT_CODE_EXIST_START_FAILED = 3
 
   /**
-    * XQTS Features which are enabled by default.
-    */
+   * XQTS Features which are enabled by default.
+   */
   private val DEFAULT_FEATURES = Seq(
     CollectionStability,
     DirectoryAsCollectionUri,
@@ -96,8 +96,8 @@ object XQTSRunner {
   )
 
   /**
-    * XQTS Specs which are enabled by default.
-    */
+   * XQTS Specs which are enabled by default.
+   */
   private val DEFAULT_SPECS = Seq(
     XP10,
     XP20,
@@ -110,8 +110,8 @@ object XQTSRunner {
   )
 
   /**
-    * XQTS XML Versions which are enabled by default.
-    */
+   * XQTS XML Versions which are enabled by default.
+   */
   private val DEFAULT_XML_VERSIONS = Seq(
     XML10,
     XML10_4thOrEarlier,
@@ -120,8 +120,8 @@ object XQTSRunner {
   )
 
   /**
-    * XQTS XSD Versions which are enabled by default.
-    */
+   * XQTS XSD Versions which are enabled by default.
+   */
   private val DEFAULT_XSD_VERSIONS = Seq.empty
 
   // Converters used for parsing the command line arguments.
@@ -132,15 +132,23 @@ object XQTSRunner {
   private implicit val specRead: scopt.Read[Spec] = scopt.Read.reads(Spec.withName(_))
   private implicit val xmlVersionRead: scopt.Read[XmlVersion] = scopt.Read.reads(XmlVersion.withName(_))
   private implicit val xsdVersionRead: scopt.Read[XsdVersion] = scopt.Read.reads(XsdVersion.withName(_))
-  private def fileExists(f: Path) : Either[String, Unit] = if(Files.exists(f)) { Right(()) } else Left(s"${f.toAbsolutePath} does not exist")
-  private def isDirOrNotExists(f: Path) : Either[String, Unit] = if(Files.isDirectory(f) || !Files.exists(f)) { Right(()) } else { Left(s"${f.toAbsolutePath} is not a writable directory")}
+
+  private def fileExists(f: Path): Either[String, Unit] = if (Files.exists(f)) {
+    Right(())
+  } else Left(s"${f.toAbsolutePath} does not exist")
+
+  private def isDirOrNotExists(f: Path): Either[String, Unit] = if (Files.isDirectory(f) || !Files.exists(f)) {
+    Right(())
+  } else {
+    Left(s"${f.toAbsolutePath} is not a writable directory")
+  }
 
 
   /**
-    * MAIN
-    *
-    * @param args the command line arguments
-    */
+   * MAIN
+   *
+   * @param args the command line arguments
+   */
   def main(args: Array[String]): Unit = {
     val parser = new scopt.OptionParser[CmdConfig]("xqtsrunner") {
       head("xqtsrunner", "1.0")
@@ -151,42 +159,42 @@ object XQTSRunner {
         .action((x, c) => c.copy(xqtsVersion = x))
 
       opt[Path]('l', "local-dir")
-        .text ("A directory where downloaded copies of XQTS are cached. If not provided then a directory 'work' within the current working directory is assumed")
+        .text("A directory where downloaded copies of XQTS are cached. If not provided then a directory 'work' within the current working directory is assumed")
         .validate(fileExists)
         .action((x, c) => c.copy(localDir = Some(x)))
 
       opt[Pattern]("test-set-pattern").abbr("tsptn")
         .text("A regular expression that matches one or more test set names to run. The default is to run all of them")
-        .action((x,c) => c.copy(testSetPattern = Some(x)))
+        .action((x, c) => c.copy(testSetPattern = Some(x)))
 
       opt[Seq[String]]("test-set").abbr("ts")
-          .valueName("<test-set-1>,<test-set-2>...")
-          .text("The name of one or more test sets to run. The default is to run all of them")
-          .action((x,c) => c.copy(testSets = x))
+        .valueName("<test-set-1>,<test-set-2>...")
+        .text("The name of one or more test sets to run. The default is to run all of them")
+        .action((x, c) => c.copy(testSets = x))
 
       opt[Pattern]("test-case-pattern").abbr("tcptn")
         .text("A regular expression that matches one or more test case names to run. The default is to run all of them")
-        .action((x,c) => c.copy(testCasePattern = Some(x)))
+        .action((x, c) => c.copy(testCasePattern = Some(x)))
 
       opt[Seq[String]]("test-case").abbr("tc")
         .valueName("<test-case-1>,<test-case-2>...")
         .text("The name of one or more test cases (within the test sets) to run. The default is to run all of them")
-        .action((x,c) => c.copy(testCases = x))
+        .action((x, c) => c.copy(testCases = x))
 
       opt[Seq[String]]("exclude-test-set").abbr("xts")
         .valueName("<test-set-1>,<test-set-2>...")
         .text("The name of one or more test sets to exclude from the run. The default is to run all of them")
-        .action((x,c) => c.copy(excludeTestSets = x))
+        .action((x, c) => c.copy(excludeTestSets = x))
 
       opt[Seq[String]]("exclude-test-case").abbr("xtc")
         .valueName("<test-case-1>,<test-case-2>...")
         .text("The name of one or more test cases to exclude (within the test sets) from the run. The default is to run all of them")
-        .action((x,c) => c.copy(excludeTestCases = x))
+        .action((x, c) => c.copy(excludeTestCases = x))
 
       opt[Seq[Feature]]("enable-feature").abbr("ef")
-          .valueName("<feature-1>,<feature-2>...")
-          .text("The name of one or more XQTS features to enable.")
-          .action((x, c) => c.copy(enableFeatures = x))
+        .valueName("<feature-1>,<feature-2>...")
+        .text("The name of one or more XQTS features to enable.")
+        .action((x, c) => c.copy(enableFeatures = x))
 
       opt[Seq[Feature]]("disable-feature").abbr("df")
         .valueName("<feature-1>,<feature-2>...")
@@ -224,9 +232,9 @@ object XQTSRunner {
         .action((x, c) => c.copy(disableXsdVersions = x))
 
       opt[Path]('o', "output-dir")
-          .text("A directory where the results of the XQTS are written. If not provided then 'target' is assumed")
-          .validate(isDirOrNotExists)
-          .action((x, c) => c.copy(outputDir = Some(x)))
+        .text("A directory where the results of the XQTS are written. If not provided then 'target' is assumed")
+        .validate(isDirOrNotExists)
+        .action((x, c) => c.copy(outputDir = Some(x)))
 
       note("The test-set-pattern argument takes preference over the test-set argument")
       note(s"By default the following features are enabled: ${DEFAULT_FEATURES.mkString(", ")}")
@@ -250,20 +258,20 @@ object XQTSRunner {
 }
 
 /**
-  * Main application class.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Main application class.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 private class XQTSRunner {
 
   private val logger = Logger(classOf[XQTSRunner])
   @scala.annotation.unused private var existServer: Option[ExistServer] = None
 
   /**
-    * Run's an XQTS against eXist-db.
-    *
-    * @param cmdConfig the command line arguments
-    */
+   * Run's an XQTS against eXist-db.
+   *
+   * @param cmdConfig the command line arguments
+   */
   private def run(cmdConfig: CmdConfig): Unit = {
     logger.info(s"eXist-db XQTS Runner starting for: ${XQTSVersion.label(cmdConfig.xqtsVersion)}")
 
@@ -314,7 +322,7 @@ private class XQTSRunner {
 
             // 4) register the shutdown process
             //TODO(AR) should likely switch to Coordinated Shutdown, see: https://doc.akka.io/docs/akka/2.5/actors.html#coordinated-shutdown
-            system.registerOnTermination (() => {
+            system.registerOnTermination(() => {
               server.stopServer()
               sys.exit(EXIT_CODE_OK)
             })
@@ -333,30 +341,26 @@ private class XQTSRunner {
   }
 
   /**
-    * Get the dependencies which are enabled.
-    *
-    * @param defaultEnabled the dependencies which are enabled by default.
-    *
-    * @param enable the dependencies to enable.
-    * @param disable the dependencies to disable.
-    *
-    * @return just the enabled dependencies.
-    */
+   * Get the dependencies which are enabled.
+   *
+   * @param defaultEnabled the dependencies which are enabled by default.
+   * @param enable         the dependencies to enable.
+   * @param disable        the dependencies to disable.
+   * @return just the enabled dependencies.
+   */
   private def getEnabled[T](defaultEnabled: Seq[T])(enable: Seq[T], disable: Seq[T]): Seq[T] = {
     (defaultEnabled ++ enable).filterNot(disable.contains(_)).toSet.toSeq
   }
 
   /**
-    * Gets the parser for the XQTS version.
-    *
-    * @param xqtsVersion the version of XQTS to parse.
-    *
-    * @return the parser for the XQTS version.
-    *
-    * @throws IllegalArgumentException if we don't support the requested XQTS version.
-    */
+   * Gets the parser for the XQTS version.
+   *
+   * @param xqtsVersion the version of XQTS to parse.
+   * @return the parser for the XQTS version.
+   * @throws IllegalArgumentException if we don't support the requested XQTS version.
+   */
   @throws[IllegalArgumentException]
-  private def getParserActorClass(xqtsVersion: XQTSVersion) : Class[_<: XQTSParserActor] = {
+  private def getParserActorClass(xqtsVersion: XQTSVersion): Class[_ <: XQTSParserActor] = {
     xqtsVersion match {
       case XQTS_3_1 | XQTS_HEAD =>
         classOf[XQTS3CatalogParserActor]
@@ -365,25 +369,25 @@ private class XQTSRunner {
   }
 
   /**
-    * Gets the serializer for the XQTS.
-    *
-    * @return the serializer for the XQTS.
-    */
-  private def getSerializerActorClass() : Class[_<: XQTSResultsSerializerActor] = {
+   * Gets the serializer for the XQTS.
+   *
+   * @return the serializer for the XQTS.
+   */
+  private def getSerializerActorClass(): Class[_ <: XQTSResultsSerializerActor] = {
     classOf[JUnitResultsSerializerActor]
   }
 
   //TODO(AR) use Cats IO for download and store ops
+
   /**
-    * Ensure that an XQTS version is present, if not it will be downloaded.
-    *
-    * @param xqtsVersion the version of XQTS
-    * @param settings the configured application settings.
-    * @param overrideLocalDir a directory to use for storing the XQTS, overrides the default setting.
-    *
-    * @return Either the path to the XQTS, or an exception
-    */
-  private def ensureXqtsPresent(xqtsVersion: XQTSVersion, settings: SettingsImpl, overrideLocalDir: Option[Path]) : Either[Throwable, Path] = {
+   * Ensure that an XQTS version is present, if not it will be downloaded.
+   *
+   * @param xqtsVersion      the version of XQTS
+   * @param settings         the configured application settings.
+   * @param overrideLocalDir a directory to use for storing the XQTS, overrides the default setting.
+   * @return Either the path to the XQTS, or an exception
+   */
+  private def ensureXqtsPresent(xqtsVersion: XQTSVersion, settings: SettingsImpl, overrideLocalDir: Option[Path]): Either[Throwable, Path] = {
     def getLocalWorkDir(hasDir: Option[String]) = {
       hasDir match {
         case Some(_) =>
@@ -392,11 +396,13 @@ private class XQTSRunner {
           overrideLocalDir.getOrElse(Paths.get(settings.xqtsLocalDir)).resolve(XQTSVersion.label(xqtsVersion))
       }
     }
+
     def hasLocalCopy(xqtsLocalPath: Path, xqtsCheckFile: String) = Files.exists(xqtsLocalPath) && Files.exists(xqtsLocalPath.resolve(xqtsCheckFile))
-    def verifySha256(path: Path, sha256: String) : Either[Throwable, Path] = {
+
+    def verifySha256(path: Path, sha256: String): Either[Throwable, Path] = {
       Checksum.checksum(path, SHA256).map(_.map(_.toChar).mkString) match {
         case Right(pathSha256) =>
-          if(sha256.equals(sha256)) {
+          if (sha256.equals(sha256)) {
             Right(path)
           } else {
             Left(new IOException(s"Downloaded file checksum is: $pathSha256 but expected $sha256"))
@@ -406,16 +412,17 @@ private class XQTSRunner {
     }
 
     def getFilename(xqtsUrl: String) = Paths.get(new URI(xqtsUrl).getPath).getFileName.toString
-    def hasDownload(xqtsUrl: String, sha256: String, xqtsLocalPath: Path) : Either[Throwable, Option[Path]] = {
+
+    def hasDownload(xqtsUrl: String, sha256: String, xqtsLocalPath: Path): Either[Throwable, Option[Path]] = {
       val downloadFile = xqtsLocalPath.resolve(getFilename(xqtsUrl))
-      if(Files.exists(downloadFile)) {
+      if (Files.exists(downloadFile)) {
         verifySha256(downloadFile, sha256).map(Some(_))
       } else {
         Right(Option.empty[Path])
       }
     }
 
-    def download(xqtsUrl: String, sha256: String, xqtsLocalPath: Path) : Either[Throwable, Path] = {
+    def download(xqtsUrl: String, sha256: String, xqtsLocalPath: Path): Either[Throwable, Path] = {
       def getFile(dest: Path): Path = {
         import sys.process._
         new URL(xqtsUrl) #> dest.toFile !!;
@@ -428,22 +435,22 @@ private class XQTSRunner {
       }
     }
 
-    def expandToLocalCopy(xqtsZip: Path, xqtsLocalPath: Path) : Either[Throwable, Path] = {
-        logger.info(s"Expanding XQTS from: $xqtsZip to: $xqtsLocalPath")
-        try {
-          // create dest if doesn't exist
-          if(!Files.exists(xqtsLocalPath)) {
-            Files.createDirectories(xqtsLocalPath)
-          }
-
-          // unzip the file
-          org.exist.xqts.runner.Unzip.unzip(xqtsZip, xqtsLocalPath)
-
-          Right(xqtsLocalPath)
-        } catch {
-          case e: IOException =>
-            Left(e)
+    def expandToLocalCopy(xqtsZip: Path, xqtsLocalPath: Path): Either[Throwable, Path] = {
+      logger.info(s"Expanding XQTS from: $xqtsZip to: $xqtsLocalPath")
+      try {
+        // create dest if doesn't exist
+        if (!Files.exists(xqtsLocalPath)) {
+          Files.createDirectories(xqtsLocalPath)
         }
+
+        // unzip the file
+        org.exist.xqts.runner.Unzip.unzip(xqtsZip, xqtsLocalPath)
+
+        Right(xqtsLocalPath)
+      } catch {
+        case e: IOException =>
+          Left(e)
+      }
     }
 
     def processXqtsVersion(xqtsVersionConfig: settings.XqtsVersionConfig): Either[Throwable, Path] = {

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -32,19 +32,18 @@ import org.exist.xqts.runner.XQTSResultsSerializerActor.{FinalizeSerialization, 
 import org.exist.xqts.runner.qt3.XQTS3TestSetParserActor
 
 import scala.annotation.unused
-import scala.collection.immutable.Map
 
 /**
-  * The supervisor actor which will coordinate all other
-  * actors in parsing, executing, and reporting on an XQTS
-  * invocation.
-  *
-  * @param xmlParserBufferSize the maximum buffer size to use for each XML
-  *                            document from the XQTS which we parse.
-  * @param existServer a reference to an eXist-db server.
-  * @param serializerActorClass the class to use for serializing the results of the XQTS.
-  * @param outputDir the directory to serialize XQTS results to.
-  */
+ * The supervisor actor which will coordinate all other
+ * actors in parsing, executing, and reporting on an XQTS
+ * invocation.
+ *
+ * @param xmlParserBufferSize  the maximum buffer size to use for each XML
+ *                             document from the XQTS which we parse.
+ * @param existServer          a reference to an eXist-db server.
+ * @param serializerActorClass the class to use for serializing the results of the XQTS.
+ * @param outputDir            the directory to serialize XQTS results to.
+ */
 class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parserActorClass: Class[XQTSParserActor], serializerActorClass: Class[XQTSResultsSerializerActor], styleDir: Option[Path], outputDir: Path) extends Actor with Timers {
 
   private val logger = Logger(classOf[XQTSRunnerActor])
@@ -54,15 +53,18 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
 
   private var unparsedTestSets: Set[TestSetRef] = Set.empty
   private var unserializedTestSets: Set[TestSetRef] = Set.empty
-  private var testCases : Map[TestSetRef, Set[String]] = Map.empty
-  private var completedTestCases : Map[TestSetRef, Map[String, TestResult]] = Map.empty
+  private var testCases: Map[TestSetRef, Set[String]] = Map.empty
+  private var completedTestCases: Map[TestSetRef, Map[String, TestResult]] = Map.empty
 
   private case object TimerStatsKey
+
   private case object TimerPrintStats
+
   private case class Stats(unparsedTestSets: Int, testCases: (Int, Int), completedTestCases: (Int, Int), unserializedTestSets: Int) {
     def asMessage: String = s"XQTSRunnerActor Progress:\nunparsedTestSets=${unparsedTestSets}\ntestCases[sets/cases]=${testCases._1}/${testCases._2}\ncompletedTestCases[sets/cases]=${completedTestCases._1}/${completedTestCases._2}\nunserializedTestSets=${unserializedTestSets}"
   }
-  private var previousStats: Stats = Stats(0, (0,0), (0,0), 0)
+
+  private var previousStats: Stats = Stats(0, (0, 0), (0, 0), 0)
   private var unchangedStatsTicks = 0;
 
   override def receive: Receive = {
@@ -77,7 +79,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
         timers.startTimerAtFixedRate(TimerStatsKey, TimerPrintStats, 5.seconds)
       }
 
-      val readFileRouter = context.actorOf(FromConfig.props(Props(classOf[ReadFileActor])), name="ReadFileRouter")
+      val readFileRouter = context.actorOf(FromConfig.props(Props(classOf[ReadFileActor])), name = "ReadFileRouter")
       val commonResourceCacheActor = context.actorOf(Props(classOf[CommonResourceCacheActor], readFileRouter, maxCacheBytes))
 
       val testCaseRunnerRouter = context.actorOf(FromConfig.props(Props(classOf[TestCaseRunnerActor], existServer, commonResourceCacheActor)), name = "TestCaseRunnerRouter")
@@ -98,10 +100,10 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
       // if stats have not changed for 5 ticks, dump some info about incomplete test sets
       if (unchangedStatsTicks > 5) {
         val incompleteTestSets = testCases
-          .map { case (testSetRef, testCaseNames) => (testSetRef, testCaseNames.removedAll(completedTestCases.get(testSetRef).map(_.keySet).getOrElse(Set.empty)))}
-          .filter {case (_, testCaseNames) => testCaseNames.nonEmpty}
+          .map { case (testSetRef, testCaseNames) => (testSetRef, testCaseNames.removedAll(completedTestCases.get(testSetRef).map(_.keySet).getOrElse(Set.empty))) }
+          .filter { case (_, testCaseNames) => testCaseNames.nonEmpty }
 
-        logger.debug(s"incompleteTestSets=${incompleteTestSets.map { case (testSetRef, testCaseNames) => (testSetRef.name, testCaseNames)}}")
+        logger.debug(s"incompleteTestSets=${incompleteTestSets.map { case (testSetRef, testCaseNames) => (testSetRef.name, testCaseNames) }}")
 
         // reset
         unchangedStatsTicks = 0;
@@ -165,7 +167,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
     context.system.terminate()
   }
 
-  private def isTestSetCompleted(testSetRef: TestSetRef) : Boolean = {
+  private def isTestSetCompleted(testSetRef: TestSetRef): Boolean = {
     unparsedTestSets.contains(testSetRef) == false &&
       completedTestCases.get(testSetRef).map(_.keySet)
         .flatMap(completed => testCases.get(testSetRef).map(_ == completed))
@@ -175,11 +177,11 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   private def allTestSetsCompleted(): Boolean = {
     unserializedTestSets.isEmpty &&
       unparsedTestSets.isEmpty &&
-        !testCases.keySet.map(isTestSetCompleted(_)).contains(false)
+      !testCases.keySet.map(isTestSetCompleted(_)).contains(false)
   }
 
   @unused
-  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef) : Map[TestSetRef, Map[String, Option[TestResult]]] = {
+  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef): Map[TestSetRef, Map[String, Option[TestResult]]] = {
     if (map.contains(testSetRef)) {
       map
     } else {
@@ -188,7 +190,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   }
 
   @unused
-  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef, testCase: String) : Map[TestSetRef, Map[String, Option[TestResult]]] = {
+  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef, testCase: String): Map[TestSetRef, Map[String, Option[TestResult]]] = {
     if (map.contains(testSetRef)) {
       if (!map(testSetRef).contains(testCase)) {
         map + (testSetRef -> (map(testSetRef) + (testCase -> None)))
@@ -201,7 +203,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   }
 
   @unused
-  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef, testCases: Seq[String]) : Map[TestSetRef, Map[String, Option[TestResult]]] = {
+  private def add(map: Map[TestSetRef, Map[String, Option[TestResult]]], testSetRef: TestSetRef, testCases: Seq[String]): Map[TestSetRef, Map[String, Option[TestResult]]] = {
     if (map.contains(testSetRef)) {
       map + (testSetRef -> (map(testSetRef) ++ testCases.filterNot(map(testSetRef).contains(_)).map((_, None)).toMap))
     } else {
@@ -209,7 +211,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
     }
   }
 
-  private def addTestCase(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCase: String) : Map[TestSetRef, Set[String]] = {
+  private def addTestCase(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCase: String): Map[TestSetRef, Set[String]] = {
     if (map.contains(testSetRef)) {
       map + (testSetRef -> (map(testSetRef) + testCase))
     } else {
@@ -217,7 +219,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
     }
   }
 
-  private def addTestCases(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCases: Seq[String]) : Map[TestSetRef, Set[String]] = {
+  private def addTestCases(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCases: Seq[String]): Map[TestSetRef, Set[String]] = {
     if (map.contains(testSetRef)) {
       map + (testSetRef -> (map(testSetRef) ++ testCases.toSet))
     } else {
@@ -226,7 +228,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   }
 
   @unused
-  private def removeOutstanding(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCase: String) : Map[TestSetRef, Set[String]] = {
+  private def removeOutstanding(map: Map[TestSetRef, Set[String]], testSetRef: TestSetRef, testCase: String): Map[TestSetRef, Set[String]] = {
     if (map.contains(testSetRef)) {
       val newValueSet = map(testSetRef) - testCase
       if (newValueSet.isEmpty) {
@@ -249,15 +251,18 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
 }
 
 /**
-  * Objects and Classes that are used for executing an XQTS.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Objects and Classes that are used for executing an XQTS.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 object XQTSRunnerActor {
   case class RunXQTS(xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], maxCacheBytes: Long, testSets: Either[Set[String], Pattern], testCases: Either[Set[String], Pattern], excludeTestSets: Set[String], excludeTestCases: Set[String])
 
   case class ParsingTestSet(testSetRef: TestSetRef)
+
   case class ParsedTestSet(testSetRef: TestSetRef, testCases: Seq[String])
+
   case class RunningTestCase(testSetRef: TestSetRef, testCase: String)
+
   case class RanTestCase(testSetRef: TestSetRef, testResult: TestResult)
 }

--- a/src/main/scala/org/exist/xqts/runner/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/package.scala
@@ -18,28 +18,31 @@
 package org.exist.xqts
 
 /**
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 package object runner {
 
   /**
-    * Enumeration of XQTS versions.
-    */
+   * Enumeration of XQTS versions.
+   */
   sealed trait XQTSVersion
+
   object XQTS_1_0 extends XQTSVersion
+
   object XQTS_3_0 extends XQTSVersion
+
   object XQTS_3_1 extends XQTSVersion
+
   object XQTS_HEAD extends XQTSVersion
 
   object XQTSVersion {
 
     /**
-      * Gets an XQTS version from a string representation.
-      *
-      * @param s the XQTS version string.
-      *
-      * @return the XQTS Version.
-      */
+     * Gets an XQTS version from a string representation.
+     *
+     * @param s the XQTS version string.
+     * @return the XQTS Version.
+     */
     @throws[IllegalArgumentException]
     def from(s: String): XQTSVersion = {
       s match {
@@ -52,12 +55,11 @@ package object runner {
     }
 
     /**
-      * Gets an XQTS version from an integer representation.
-      *
-      * @param i the XQTS version number.
-      *
-      * @return the XQTS Version.
-      */
+     * Gets an XQTS version from an integer representation.
+     *
+     * @param i the XQTS version number.
+     * @return the XQTS Version.
+     */
     @throws[IllegalArgumentException]
     def from(i: Int): XQTSVersion = {
       i match {
@@ -70,12 +72,11 @@ package object runner {
     }
 
     /**
-      * Gets an XQTS version from a numeric representation.
-      *
-      * @param f the XQTS version number.
-      *
-      * @return the XQTS Version.
-      */
+     * Gets an XQTS version from a numeric representation.
+     *
+     * @param f the XQTS version number.
+     * @return the XQTS Version.
+     */
     @throws[IllegalArgumentException]
     def from(f: Float) = {
       f match {
@@ -88,13 +89,12 @@ package object runner {
     }
 
     /**
-      * Gets the XQTS version label string.
-      *
-      * @param xqtsVersion the XQTS version.
-      *
-      * @return the XQTS version label string.
-      */
-    def label(xqtsVersion: XQTSVersion) : String = {
+     * Gets the XQTS version label string.
+     *
+     * @param xqtsVersion the XQTS version.
+     * @return the XQTS version label string.
+     */
+    def label(xqtsVersion: XQTSVersion): String = {
       xqtsVersion match {
         case XQTS_1_0 =>
           "XQTS_1_0"
@@ -108,13 +108,12 @@ package object runner {
     }
 
     /**
-      * Gets the XQTS version name string.
-      *
-      * @param xqtsVersion the XQTS version.
-      *
-      * @return the XQTS version name string.
-      */
-    def toVersionName(xqtsVersion: XQTSVersion) : String = {
+     * Gets the XQTS version name string.
+     *
+     * @param xqtsVersion the XQTS version.
+     * @return the XQTS version name string.
+     */
+    def toVersionName(xqtsVersion: XQTSVersion): String = {
       xqtsVersion match {
         case XQTS_1_0 =>
           "1.0"

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3CatalogParserActor.scala
@@ -42,18 +42,17 @@ import org.exist.xqts.runner.qt3.XQTS3TestSetParserActor.ParseTestSet
 import scala.annotation.tailrec
 
 /**
-  * Parser an XQTS 3.1 catalog.xml file.
-  *
-  * For each reference to a test-set file parsed from the catalog,
-  * a parse request of {@link ParseTestSet} will be sent
-  * to a {@link XQTS3TestSetParserActor}.
-  *
-  * @param xmlParserBufferSize the maximum buffer size to use for each XML
-  *                            document from the XQTS which we parse.
-  * @param testSetParserRouter a router to a pool of test-set parsers.
-  *
-  * @author Adam Retter <adam@evolvedbinary.com>
-  */
+ * Parser an XQTS 3.1 catalog.xml file.
+ *
+ * For each reference to a test-set file parsed from the catalog,
+ * a parse request of [[ParseTestSet]] will be sent
+ * to a [[XQTS3TestSetParserActor]].
+ *
+ * @param xmlParserBufferSize the maximum buffer size to use for each XML
+ *                            document from the XQTS which we parse.
+ * @param testSetParserRouter a router to a pool of test-set parsers.
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 class XQTS3CatalogParserActor(xmlParserBufferSize: Int, testSetParserRouter: ActorRef) extends XQTSParserActor {
 
   private val logger = Logger(classOf[XQTS3CatalogParserActor])
@@ -79,45 +78,42 @@ class XQTS3CatalogParserActor(xmlParserBufferSize: Int, testSetParserRouter: Act
       logger.info("Parsed XQTS Catalog OK.")
       sender ! ParseComplete(xqtsVersion, xqtsPath, matchedTestSets)
 
-      context.stop(self)  // we are no longer needed
+      context.stop(self) // we are no longer needed
   }
 
   /**
-    * Parses a XQTS catalog.xml file.
-    *
-    * Each test-set which is not excluded from the parse
-    * will be dispatched to a {@link XQTS3TestSetParserActor}.
-    *
-    * @param xqtsRunner a reference to the XQTSRunnerActor
-    * @param xqtsVersion the version of the XQTS.
-    * @param xqtsPath the path to the XQTS.
-    * @param features the enabled XQTS features to support.
-    * @param specs the enabled XQTS specs to support.
-    * @param xmlVersions the enabled XQTS XML versions to support.
-    * @param xsdVersions the enabled XQTS XSD versions to support.
-    * @param testSets the test-sets to parse, or an empty set to parse all.
-    * @param testCases the test-cases to parse, or an empty set to parse all.
-    * @param excludeTestSets the names of any test sets to exclude from the parse.
-    * @param excludeTestCases the names of any test cases to exclude from the parse.
-    *
-    * @return the number of test sets that were matched in the catalog and dispatched to the testSetParserRouter.
-    */
-  private def parseCatalog(xqtsRunner: ActorRef, xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], testSets: Either[Set[String], Pattern], testCases: Either[Set[String], Pattern], excludeTestSets: Set[String], excludeTestCases: Set[String]) : Int = {
+   * Parses a XQTS catalog.xml file.
+   *
+   * Each test-set which is not excluded from the parse
+   * will be dispatched to a [[XQTS3TestSetParserActor]].
+   *
+   * @param xqtsRunner       a reference to the XQTSRunnerActor
+   * @param xqtsVersion      the version of the XQTS.
+   * @param xqtsPath         the path to the XQTS.
+   * @param features         the enabled XQTS features to support.
+   * @param specs            the enabled XQTS specs to support.
+   * @param xmlVersions      the enabled XQTS XML versions to support.
+   * @param xsdVersions      the enabled XQTS XSD versions to support.
+   * @param testSets         the test-sets to parse, or an empty set to parse all.
+   * @param testCases        the test-cases to parse, or an empty set to parse all.
+   * @param excludeTestSets  the names of any test sets to exclude from the parse.
+   * @param excludeTestCases the names of any test cases to exclude from the parse.
+   * @return the number of test sets that were matched in the catalog and dispatched to the testSetParserRouter.
+   */
+  private def parseCatalog(xqtsRunner: ActorRef, xqtsVersion: XQTSVersion, xqtsPath: Path, features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], testSets: Either[Set[String], Pattern], testCases: Either[Set[String], Pattern], excludeTestSets: Set[String], excludeTestCases: Set[String]): Int = {
 
     /**
-      * The asynchronous STaX parsing loop,
-      * implemented as a recursive function.
-      *
-      * @param event the current STaX event.
-      * @param asyncReader the asynchronous XML stream reader.
-      * @param xqtsPath the path to the directory containing the catalog.xml.
-      * @param channel the file channel for the {@code asyncReader}.
-      * @param buf the buffer for the {@code asyncReader}.
-      *
-      * @return the number of test sets that were matched in the catalog and dispatched to the testSetParserRouter.
-      *
-      * @throws XQTSParseException if an error happens during parsing.
-      */
+     * The asynchronous STaX parsing loop,
+     * implemented as a recursive function.
+     *
+     * @param event       the current STaX event.
+     * @param asyncReader the asynchronous XML stream reader.
+     * @param xqtsPath    the path to the directory containing the catalog.xml.
+     * @param channel     the file channel for the  <pre>asyncReader</pre> .
+     * @param buf         the buffer for the  <pre>asyncReader</pre> .
+     * @return the number of test sets that were matched in the catalog and dispatched to the testSetParserRouter.
+     * @throws XQTSParseException if an error happens during parsing.
+     */
     @tailrec
     @throws[XQTSParseException]
     def parseAll(event: Int, asyncReader: AsyncXMLStreamReader[AsyncByteBufferFeeder], xqtsPath: Path, channel: SeekableByteChannel, buf: ByteBuffer, matchedTestSets: Int = 0): Int = {
@@ -125,7 +121,7 @@ class XQTS3CatalogParserActor(xmlParserBufferSize: Int, testSetParserRouter: Act
 
       event match {
         case END_DOCUMENT =>
-          return matchedTestSets  // exit parse
+          return matchedTestSets // exit parse
 
         case START_ELEMENT if (asyncReader.getLocalName == ELEM_ENVIRONMENT) =>
           val name = asyncReader.getAttributeValue(ATTR_NAME)
@@ -248,16 +244,28 @@ class XQTS3CatalogParserActor(xmlParserBufferSize: Int, testSetParserRouter: Act
           }
 
         case _ =>
-          // we can ignore anything else
+        // we can ignore anything else
       }
 
-      val updatedMatchedTestSets : Int = if (matchedTestSet) matchedTestSets + 1 else matchedTestSets
+      val updatedMatchedTestSets: Int = if (matchedTestSet) matchedTestSets + 1 else matchedTestSets
       parseAll(asyncReader.next(), asyncReader, xqtsPath, channel, buf, updatedMatchedTestSets)
     }
 
-    val bufIO = cats.effect.Resource.make(IO { ByteBuffer.allocate(xmlParserBufferSize) })(buf => IO { buf.clear() })
-    val fileIO = cats.effect.Resource.make(IO { Files.newByteChannel(xqtsPath.resolve(CATALOG_FILE)) })(channel => IO {channel.close() })
-    val asyncParserIO = cats.effect.Resource.make(IO { PARSER_FACTORY.createAsyncForByteBuffer() } )(asyncReader => IO { asyncReader.close() })
+    val bufIO = cats.effect.Resource.make(IO {
+      ByteBuffer.allocate(xmlParserBufferSize)
+    })(buf => IO {
+      buf.clear()
+    })
+    val fileIO = cats.effect.Resource.make(IO {
+      Files.newByteChannel(xqtsPath.resolve(CATALOG_FILE))
+    })(channel => IO {
+      channel.close()
+    })
+    val asyncParserIO = cats.effect.Resource.make(IO {
+      PARSER_FACTORY.createAsyncForByteBuffer()
+    })(asyncReader => IO {
+      asyncReader.close()
+    })
     val parseIO = bufIO.use(buf =>
       fileIO.use(channel =>
         asyncParserIO.use(asyncReader =>
@@ -278,7 +286,7 @@ class XQTS3CatalogParserActor(xmlParserBufferSize: Int, testSetParserRouter: Act
 
 object XQTS3CatalogParserActor {
   /**
-    * Name of the XQTS 3.1 Catalog file
-    */
+   * Name of the XQTS 3.1 Catalog file
+   */
   private val CATALOG_FILE = "catalog.xml"
 }

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -44,19 +44,18 @@ import java.util.regex.Pattern
 import scala.annotation.tailrec
 
 /**
-  * Parser an XQTS 3.1 test-set XML file.
-  *
-  * For each test-case parsed from the test-set,
-  * an execution request of {@link RunTestCase} will be sent
-  * to a {@link TestCaseRunnerActor}.
-  *
-  * @param xmlParserBufferSize the maximum buffer size to use for each XML
-  *                            document from the XQTS which we parse.
-  * @param testCaseRunnerActor a reference to an actor which can execute
-  *                            an XQTS test-case.
-  *
-  * @author Adam Retter <adam@evolvedinary.com>
-  */
+ * Parser an XQTS 3.1 test-set XML file.
+ *
+ * For each test-case parsed from the test-set,
+ * an execution request of [[RunTestCase]] will be sent
+ * to a [[org.exist.xqts.runner.TestCaseRunnerActor]].
+ *
+ * @param xmlParserBufferSize the maximum buffer size to use for each XML
+ *                            document from the XQTS which we parse.
+ * @param testCaseRunnerActor a reference to an actor which can execute
+ *                            an XQTS test-case.
+ * @author Adam Retter <adam@evolvedinary.com>
+ */
 class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: ActorRef) extends Actor {
 
   private val logger = Logger(classOf[XQTS3TestSetParserActor])
@@ -98,38 +97,37 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
   }
 
   /**
-    * Parses an XQTS test-set XML file.
-    *
-    * @param testSetRef a reference to the test-set.
-    * @param testCases the test-cases to parse, or an empty set to parse all.
-    * @param features the enabled XQTS features to support.
-    * @param specs the enabled XQTS specs to support.
-    * @param xmlVersions the enabled XQTS XML versions to support.
-    * @param xsdVersions the enabled XQTS XSD versions to support.
-    * @param excludeTestCases the names of any test cases to exclude from the parse.
-    * @param globalEnvironments any environemnts which were defined globally in the XQTS catalog.
-    * @param manager the supervising manager actor.
-    *
-    * @return Some of the parsed test-set, or None.
-    */
-  private def parseTestSet(testSetRef: TestSetRef, testCases: Either[Set[String], Pattern], features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], excludeTestCases: Set[String], globalEnvironments: Map[String, Environment], manager: ActorRef) : Option[TestSet] = {
+   * Parses an XQTS test-set XML file.
+   *
+   * @param testSetRef         a reference to the test-set.
+   * @param testCases          the test-cases to parse, or an empty set to parse all.
+   * @param features           the enabled XQTS features to support.
+   * @param specs              the enabled XQTS specs to support.
+   * @param xmlVersions        the enabled XQTS XML versions to support.
+   * @param xsdVersions        the enabled XQTS XSD versions to support.
+   * @param excludeTestCases   the names of any test cases to exclude from the parse.
+   * @param globalEnvironments any environemnts which were defined globally in the XQTS catalog.
+   * @param manager            the supervising manager actor.
+   * @return Some of the parsed test-set, or None.
+   */
+  private def parseTestSet(testSetRef: TestSetRef, testCases: Either[Set[String], Pattern], features: Set[Feature], specs: Set[Spec], xmlVersions: Set[XmlVersion], xsdVersions: Set[XsdVersion], excludeTestCases: Set[String], globalEnvironments: Map[String, Environment], manager: ActorRef): Option[TestSet] = {
 
     /**
-      * Get's an environment.
-      *
-      * First searches the environments of the test set,
-      * and the falls-back and searches the environments
-      * of the catalog.
-      *
-      * @param ref The reference to the environment.
-      * @return The environment if known.
-      */
-    def getEnvironment(ref: String) : Option[Environment] = {
+     * Get's an environment.
+     *
+     * First searches the environments of the test set,
+     * and the falls-back and searches the environments
+     * of the catalog.
+     *
+     * @param ref The reference to the environment.
+     * @return The environment if known.
+     */
+    def getEnvironment(ref: String): Option[Environment] = {
       environments.get(ref)
         .orElse(globalEnvironments.get(ref))
     }
 
-    def matchesTestCases(testCaseName: String) : Boolean = {
+    def matchesTestCases(testCaseName: String): Boolean = {
       if (excludeTestCases.contains(testCaseName)) {
         return false
       }
@@ -144,25 +142,23 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
     }
 
     /**
-      * The asynchronous STaX parsing loop,
-      * implemented as a recursive function.
-      *
-      * @param event the current STaX event.
-      * @param asyncReader the asynchronous XML stream reader.
-      * @param testSetDir the path to the directory containing the test-set.
-      * @param channel the file channel for the {@code asyncReader}.
-      * @param buf the buffer for the {@code asyncReader}.
-      *
-      * @return Some of the parsed test-set, or None.
-      *
-      * @throws XQTSParseException if an error happens during parsing.
-      */
+     * The asynchronous STaX parsing loop,
+     * implemented as a recursive function.
+     *
+     * @param event       the current STaX event.
+     * @param asyncReader the asynchronous XML stream reader.
+     * @param testSetDir  the path to the directory containing the test-set.
+     * @param channel     the file channel for the  <pre>asyncReader</pre> .
+     * @param buf         the buffer for the  <pre>asyncReader</pre> .
+     * @return Some of the parsed test-set, or None.
+     * @throws XQTSParseException if an error happens during parsing.
+     */
     @tailrec
     @throws[XQTSParseException]
-    def parseAll(event: Int, asyncReader: AsyncXMLStreamReader[AsyncByteBufferFeeder], testSetDir: Path, channel: SeekableByteChannel, buf: ByteBuffer) : Option[TestSet] = {
+    def parseAll(event: Int, asyncReader: AsyncXMLStreamReader[AsyncByteBufferFeeder], testSetDir: Path, channel: SeekableByteChannel, buf: ByteBuffer): Option[TestSet] = {
       event match {
         case END_DOCUMENT =>
-          return currentTestSet  // exit parse
+          return currentTestSet // exit parse
 
         case START_ELEMENT if (asyncReader.getLocalName == ELEM_ENVIRONMENT) =>
           asyncReader.getAttributeValueOptNE(ATTR_REF) match {
@@ -174,7 +170,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
             case Some(ref) =>
               // Reference to an (already) defined environment
               getEnvironment(ref) match {
-                case env @ Some(_) =>
+                case env@Some(_) =>
                   currentTestCase = currentTestCase.map(testCase => testCase.copy(environment = env))
                 case None =>
                   throw XQTSParseException(s"Environment '$ref' was referenced, but not defined. Test set '${testSetRef.name}'${currentTestCase.map(testCase => s" for test case '${testCase.name}'").getOrElse("")}")
@@ -237,9 +233,9 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentDependency = Some(Dependency(DependencyType.fromXqtsName(`type`), value, satisfied))
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_DEPENDENCY) =>
-          if(currentTestCase.nonEmpty) {
+          if (currentTestCase.nonEmpty) {
             currentTestCase = currentDependency.map(dependency => currentTestCase.map(testCase => testCase.copy(dependencies = dependency +: testCase.dependencies))).getOrElse(currentTestCase)
-          } else if(currentTestSet.nonEmpty && !parsingTestCases) {
+          } else if (currentTestSet.nonEmpty && !parsingTestCases) {
             currentTestSet = currentDependency.map(dependency => currentTestSet.map(testSet => testSet.copy(dependencies = dependency +: testSet.dependencies))).getOrElse(currentTestSet)
           }
           currentDependency = None
@@ -250,7 +246,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentCreated = Some(Created(by, on))
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_CREATED) =>
-          if(currentTestCase.nonEmpty) {
+          if (currentTestCase.nonEmpty) {
             currentTestCase = currentTestCase.map(testCase => testCase.copy(created = currentCreated))
           } else if (currentSchema.nonEmpty) {
             currentSchema = currentSchema.map(schema => schema.copy(created = currentCreated))
@@ -268,7 +264,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentModified = Some(Modified(by, on, change))
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_MODIFIED) =>
-          if(currentTestCase.nonEmpty) {
+          if (currentTestCase.nonEmpty) {
             currentTestCase = currentModified.map(modified => currentTestCase.map(testCase => testCase.copy(modifications = modified +: testCase.modifications))).getOrElse(currentTestCase)
           } else if (currentSchema.nonEmpty) {
             currentSchema = currentModified.flatMap(modified => currentSchema.map(schema => schema.copy(modifications = modified +: schema.modifications)))
@@ -280,7 +276,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentModified = None
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_SCHEMA && currentEnv.nonEmpty) =>
-          currentEnv = currentSchema.map(schema => currentEnv.map(env => env.copy(schemas =  schema +: env.schemas)))
+          currentEnv = currentSchema.map(schema => currentEnv.map(env => env.copy(schemas = schema +: env.schemas)))
             .getOrElse(currentEnv)
           currentSchema = None
 
@@ -334,7 +330,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           val select = asyncReader.getAttributeValueOptNE(ATTR_SELECT)
           currentEnv = currentEnv.map(_.copy(contextItem = select))
 
-        case START_ELEMENT if(asyncReader.getLocalName == ELEM_DECIMAL_FORMAT && currentEnv.nonEmpty) =>
+        case START_ELEMENT if (asyncReader.getLocalName == ELEM_DECIMAL_FORMAT && currentEnv.nonEmpty) =>
           val name = asyncReader.getAttributeValueOptNE(ATTR_NAME).map(toQName(_, asyncReader.getNamespaceContext))
           val decimalSeparator = asyncReader.getAttributeValueOptNE(ATTR_DECIMAL_SEPARATOR).map(_.codePointAt(0))
           val exponentSeparator = asyncReader.getAttributeValueOptNE(ATTR_EXPONENT_SEPARATOR).map(_.codePointAt(0))
@@ -390,7 +386,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_TEST_SET) =>
           parsingTestCases = false
-          // there is nothing more we need to do here, although in future we could add further logging here
+        // there is nothing more we need to do here, although in future we could add further logging here
 
         case START_ELEMENT if (asyncReader.getLocalName == ELEM_TEST_CASE) =>
           parsingTestCases = true
@@ -413,36 +409,36 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case START_ELEMENT if(currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_RESULT) =>
+        case START_ELEMENT if (currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_RESULT) =>
           currentResult = Some(Stack.empty)
 
-        case START_ELEMENT if(asyncReader.getLocalName == ELEM_ALL_OF) =>
+        case START_ELEMENT if (asyncReader.getLocalName == ELEM_ALL_OF) =>
           currentResult = currentResult.map(addAssertion(_)(AllOf(List.empty)))
 
-        case START_ELEMENT if(asyncReader.getLocalName == ELEM_ANY_OF) =>
+        case START_ELEMENT if (asyncReader.getLocalName == ELEM_ANY_OF) =>
           currentResult = currentResult.map(addAssertion(_)(AnyOf(List.empty)))
 
-        case START_ELEMENT if(asyncReader.getLocalName == ELEM_NOT) =>
+        case START_ELEMENT if (asyncReader.getLocalName == ELEM_NOT) =>
           currentResult = currentResult.map(addAssertion(_)(Not()))
 
-        case START_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_STRING_VALUE) =>
+        case START_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_STRING_VALUE) =>
           currentNormalizeSpace = asyncReader.getAttributeValueOptNE(ATTR_NORMALIZE_SPACE).map(_.toBoolean)
           captureText = true
 
-        case START_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_XML) =>
+        case START_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_XML) =>
           val attrFile = asyncReader.getAttributeValueOptNE(ATTR_FILE)
           currentFile = attrFile.map(file => testSetRef.file.resolveSibling(file))
           currentIgnorePrefixes = asyncReader.getAttributeValueOptNE(ATTR_IGNORE_PREFIXES).map(_.toBoolean)
           captureText = true
 
-        case START_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_SERIALIZATION_MATCHES) =>
+        case START_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_SERIALIZATION_MATCHES) =>
           val attrFile = asyncReader.getAttributeValueOptNE(ATTR_FILE)
           currentFile = attrFile.map(file => testSetRef.file.resolveSibling(file))
           currentFlags = asyncReader.getAttributeValueOptNE(ATTR_FLAGS)
           captureText = true
 
         // assertions where we just need their text()
-        case START_ELEMENT if(currentResult.nonEmpty && (
+        case START_ELEMENT if (currentResult.nonEmpty && (
           asyncReader.getLocalName == ELEM_ASSERT
             || asyncReader.getLocalName == ELEM_ASSERT_COUNT
             || asyncReader.getLocalName == ELEM_ASSERT_DEEP_EQ
@@ -452,12 +448,12 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           )) =>
           captureText = true
 
-        case START_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_SERIALIZATION_ERROR) =>
+        case START_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_SERIALIZATION_ERROR) =>
           val code = asyncReader.getAttributeValue(ATTR_CODE)
           val assertion = AssertSerializationError(code)
           currentResult = currentResult.map(addAssertion(_)(assertion))
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT) =>
           currentText match {
             case Some(text) =>
               val assertion = Assert(text)
@@ -468,7 +464,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_COUNT) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_COUNT) =>
           currentText match {
             case Some(text) =>
               val assertion = AssertCount(text.trim.toInt)
@@ -479,7 +475,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_DEEP_EQ) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_DEEP_EQ) =>
           currentText match {
             case Some(text) =>
               val assertion = AssertDeepEquals(text)
@@ -490,7 +486,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_EQ) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_EQ) =>
           currentText match {
             case Some(text) =>
               val assertion = AssertEq(text)
@@ -501,7 +497,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_PERMUTATION) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_PERMUTATION) =>
           currentText match {
             case Some(text) =>
               val assertion = AssertPermutation(text)
@@ -512,14 +508,14 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_STRING_VALUE) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_STRING_VALUE) =>
           val assertion = AssertStringValue(currentText.getOrElse(""), currentNormalizeSpace.getOrElse(false))
           currentResult = currentResult.map(addAssertion(_)(assertion))
           currentNormalizeSpace = None
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_TYPE) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_TYPE) =>
           currentText match {
             case Some(text) =>
               val assertion = AssertType(text)
@@ -530,11 +526,11 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_XML) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ASSERT_XML) =>
           currentText
-              .flatMap(text => Some(Left(text)))
-              .orElse(currentFile.map(Right(_)))
-              .map(AssertXml(_, currentIgnorePrefixes.getOrElse(false))) match {
+            .flatMap(text => Some(Left(text)))
+            .orElse(currentFile.map(Right(_)))
+            .map(AssertXml(_, currentIgnorePrefixes.getOrElse(false))) match {
             case Some(assertXml) =>
               currentResult = currentResult.map(addAssertion(_)(assertXml))
             case None =>
@@ -545,7 +541,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_SERIALIZATION_MATCHES) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_SERIALIZATION_MATCHES) =>
           currentText
             .flatMap(text => Some(Left(text)))
             .orElse(currentFile.map(Right(_)))
@@ -560,27 +556,27 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentText = None
           captureText = false
 
-        case END_ELEMENT if(asyncReader.getLocalName == ELEM_ASSERT_EMPTY) =>
+        case END_ELEMENT if (asyncReader.getLocalName == ELEM_ASSERT_EMPTY) =>
           currentResult = currentResult.map(addAssertion(_)(AssertEmpty))
 
-        case END_ELEMENT if(asyncReader.getLocalName == ELEM_ASSERT_FALSE) =>
+        case END_ELEMENT if (asyncReader.getLocalName == ELEM_ASSERT_FALSE) =>
           currentResult = currentResult.map(addAssertion(_)(AssertFalse))
 
-        case END_ELEMENT if(asyncReader.getLocalName == ELEM_ASSERT_TRUE) =>
+        case END_ELEMENT if (asyncReader.getLocalName == ELEM_ASSERT_TRUE) =>
           currentResult = currentResult.map(addAssertion(_)(AssertTrue))
 
-        case END_ELEMENT if(asyncReader.getLocalName == ELEM_ALL_OF || asyncReader.getLocalName == ELEM_ANY_OF) =>
+        case END_ELEMENT if (asyncReader.getLocalName == ELEM_ALL_OF || asyncReader.getLocalName == ELEM_ANY_OF) =>
           currentResult = currentResult.map(stepOutAssertions)
 
-        case END_ELEMENT if(asyncReader.getLocalName == ELEM_ALL_OF || asyncReader.getLocalName == ELEM_NOT) =>
+        case END_ELEMENT if (asyncReader.getLocalName == ELEM_ALL_OF || asyncReader.getLocalName == ELEM_NOT) =>
           currentResult = currentResult.map(stepOutAssertions)
 
-        case START_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ERROR) =>
+        case START_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_ERROR) =>
           val code = asyncReader.getAttributeValue(ATTR_CODE)
           val assertion = Error(code)
           currentResult = currentResult.map(addAssertion(_)(assertion))
 
-        case END_ELEMENT if(currentResult.nonEmpty && asyncReader.getLocalName == ELEM_RESULT) =>
+        case END_ELEMENT if (currentResult.nonEmpty && asyncReader.getLocalName == ELEM_RESULT) =>
           currentTestCase = currentTestCase.map(_.copy(result = currentResult.flatMap(_.peekOption)))
           currentResult = None
 
@@ -590,7 +586,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
             case Some(testCase) =>
               if (matchesTestCases(testCase.name)) {
                 currentTestSet = currentTestSet.map(testSet => testSet.copy(testCases = testCase +: testSet.testCases))
-                val allDependencies : Seq[Dependency] = currentTestSet.map(testSet => (testSet.dependencies.toSet ++ testCase.dependencies.toSet).toSeq).getOrElse(testCase.dependencies)
+                val allDependencies: Seq[Dependency] = currentTestSet.map(testSet => (testSet.dependencies.toSet ++ testCase.dependencies.toSet).toSeq).getOrElse(testCase.dependencies)
                 val missingDeps: Missing = missingDependencies(allDependencies, features, specs, xmlVersions, xsdVersions)
                 if (missingDeps.isEmpty) {
                   testCaseRunnerActor ! RunTestCase(testSetRef.copy(name = currentTestSet.map(_.name).getOrElse("<UNKNOWN>")), testCase, manager)
@@ -605,14 +601,14 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
               }
               currentTestCase = None
             case None =>
-              //throw XQTSParseException(s"Encountered end of element: $ELEM_TEST_CASE, but no test case was captured")
+            //throw XQTSParseException(s"Encountered end of element: $ELEM_TEST_CASE, but no test case was captured")
           }
 
         case CHARACTERS if (captureText) =>
           val characters: String = asyncReader.getText
           currentText = currentText.map(_ ++ characters).orElse(Some(characters))
 
-        case CDATA if(captureText) =>
+        case CDATA if (captureText) =>
           val characters: String = asyncReader.getText
           currentText = currentText.map(_ ++ characters).orElse(Some(characters))
 
@@ -639,19 +635,19 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
         val localPart = s.substring(idx + 1)
 
         Option(namespaceContext.getNamespaceURI(prefix))
-            .orElse(currentEnv
-              .map(_.namespaces).getOrElse(List.empty)
-              .filter(_.prefix.equals(prefix))
-              .map(_.uri.toString)
-              .headOption)
-            .map(ns => new QName(ns, localPart, prefix))
-            .getOrElse(QName.valueOf(s))
+          .orElse(currentEnv
+            .map(_.namespaces).getOrElse(List.empty)
+            .filter(_.prefix.equals(prefix))
+            .map(_.uri.toString)
+            .headOption)
+          .map(ns => new QName(ns, localPart, prefix))
+          .getOrElse(QName.valueOf(s))
       } else {
         QName.valueOf(s)
       }
     }
 
-    def addAssertion(currentAssertions: Stack[Result])(assertion: Result) : Stack[Result] = {
+    def addAssertion(currentAssertions: Stack[Result])(assertion: Result): Stack[Result] = {
       currentAssertions.peekOption match {
         case Some(head) if (head.isInstanceOf[Assertions] && !assertion.isInstanceOf[Assertions]) =>
           // head of the stack is itself a list of assertions, and the assertion to add is not a list of assertions
@@ -662,14 +658,14 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           currentAssertions.replace(Not(Some(assertion)))
 
         case Some(_) =>
-            currentAssertions.push(assertion)
+          currentAssertions.push(assertion)
 
         case None =>
           Stack(assertion)
       }
     }
 
-    def stepOutAssertions(currentAssertions: Stack[Result]) : Stack[Result] = {
+    def stepOutAssertions(currentAssertions: Stack[Result]): Stack[Result] = {
       if (currentAssertions.size >= 2) {
         if (currentAssertions.peek.isInstanceOf[Assertions]) {
           val (prevHead, stack) = currentAssertions.pop()
@@ -687,9 +683,21 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
       }
     }
 
-    val bufIO = cats.effect.Resource.make(IO { ByteBuffer.allocate(xmlParserBufferSize) })(buf => IO { buf.clear() })
-    val fileIO = cats.effect.Resource.make(IO { Files.newByteChannel(testSetRef.file) })(channel => IO {channel.close() })
-    val asyncParserIO = cats.effect.Resource.make(IO { PARSER_FACTORY.createAsyncForByteBuffer() } )(asyncReader => IO { asyncReader.close() })
+    val bufIO = cats.effect.Resource.make(IO {
+      ByteBuffer.allocate(xmlParserBufferSize)
+    })(buf => IO {
+      buf.clear()
+    })
+    val fileIO = cats.effect.Resource.make(IO {
+      Files.newByteChannel(testSetRef.file)
+    })(channel => IO {
+      channel.close()
+    })
+    val asyncParserIO = cats.effect.Resource.make(IO {
+      PARSER_FACTORY.createAsyncForByteBuffer()
+    })(asyncReader => IO {
+      asyncReader.close()
+    })
     val parseIO = bufIO.use(buf =>
       fileIO.use(channel =>
         asyncParserIO.use(asyncReader =>

--- a/src/main/scala/org/exist/xqts/runner/qt3/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/package.scala
@@ -22,8 +22,8 @@ import com.fasterxml.aalto.{AsyncInputFeeder, AsyncXMLStreamReader}
 import javax.xml.XMLConstants
 
 /**
-  * @author Adam Retter <adam@evolvedbinay.com>
-  */
+ * @author Adam Retter <adam@evolvedbinay.com>
+ */
 package object qt3 {
 
   /*
@@ -110,11 +110,13 @@ package object qt3 {
   private[qt3] val PARSER_FACTORY = new InputFactoryImpl
 
   /**
-    * Adds some convenience methods to {@link AsyncXMLStreamReader}.
-    */
-  implicit class AsyncXMLStreamReaderPimp[F <: AsyncInputFeeder](asyncXmlStreamReader : AsyncXMLStreamReader[F]) {
-    def getAttributeValue(localName: String) : String = asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName)
-    def getAttributeValueOpt(localName: String) : Option[String] = Option(asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName))
-    def getAttributeValueOptNE(localName: String) : Option[String] = getAttributeValueOpt(localName).filter(_.nonEmpty)
+   * Adds some convenience methods to [[AsyncXMLStreamReader]].
+   */
+  implicit class AsyncXMLStreamReaderPimp[F <: AsyncInputFeeder](asyncXmlStreamReader: AsyncXMLStreamReader[F]) {
+    def getAttributeValue(localName: String): String = asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName)
+
+    def getAttributeValueOpt(localName: String): Option[String] = Option(asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName))
+
+    def getAttributeValueOptNE(localName: String): Option[String] = getAttributeValueOpt(localName).filter(_.nonEmpty)
   }
 }


### PR DESCRIPTION
Use IntelliJ IDEA scala formatter to reformat the code base

[Diff that ignores whitespace changes](https://github.com/eXist-db/exist-xqts-runner/pull/40/files?diff=split&w=1) will give you a better idea, what significant changes that entails.

In DocBlocks `{@link CLASS}` and `{@code CODE}` were replaced by `[[CLASS]]` and `<pre>CODE</pre>`
 