### PR TITLE
build: remove staticTyping from DEFAULT_FEATURES

### DIFF
--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -88,7 +88,6 @@ object XQTSRunner {
     HigherOrderFunctions,
     ModuleImport,
     Serialization,
-    StaticTyping,
     TypedData,
     XPath_1_0_Compatibility,
     TransformXSLT,


### PR DESCRIPTION
The StaticTyping will be removed permanently from the default features it executes.

Reasons for this decision:

1. exist-db has had only hap-hazard support for it and this will be removed entirely with version 7.0.0
   So, testing for these features would muddy the XQTS results instead of providing us with a good measure of how good we cover the XQuery specification.

2. On top of that, the feature is also removed from the upcoming XQuery 4.0 specification.

needed for https://github.com/eXist-db/exist/pull/5673