### PR TITLE
Fix ATTR_EXPONENT_SEPARATOR attribute name

### DIFF
--- a/src/main/scala/org/exist/xqts/runner/qt3/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/package.scala
@@ -95,7 +95,7 @@ package object qt3 {
   val ATTR_MEDIA_TYPE = "media-type"
   val ATTR_ENCODING = "encoding"
   val ATTR_DECIMAL_SEPARATOR = "decimal-separator"
-  val ATTR_EXPONENT_SEPARATOR = "decimal-separator"
+  val ATTR_EXPONENT_SEPARATOR = "exponent-separator"
   val ATTR_GROUPING_SEPARATOR = "grouping-separator"
   val ATTR_ZERO_DIGIT = "zero-digit"
   val ATTR_DIGIT = "digit"


### PR DESCRIPTION
## Summary
- Fix copy-paste typo in `package.scala` line 98: `ATTR_EXPONENT_SEPARATOR` was incorrectly set to `"decimal-separator"` instead of `"exponent-separator"`
- This caused the exponent-separator property to be ignored when parsing `decimal-format` declarations from XQTS test cases

## Test plan
- [ ] Run XQTS `fn-format-number` test group and verify exponent-separator-related test cases pass correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)