### PR TITLE
[feature] Emit runner-info.xml with build SHA + JAR sha256 alongside JUnit output

### DIFF
--- a/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/JUnitResultsSerializerActor.scala
@@ -21,6 +21,7 @@ import cats.effect.unsafe.IORuntime
 
 import java.io.{BufferedOutputStream, OutputStream}
 import java.nio.file.{Files, Path}
+import java.time.Instant
 import cats.effect.{IO, Resource}
 import junit.framework.{AssertionFailedError, Test => JUTest, TestResult => JUTestResult}
 import net.sf.saxon.TransformerFactoryImpl
@@ -43,10 +44,21 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
 
   private val logger = Logger(classOf[JUnitResultsSerializerActor])
 
+  // Captured at actor creation rather than at first message so the timestamp
+  // brackets the full XQTS run, not just the serialization phase.
+  private val runStarted: Instant = Instant.now()
+  private var observedXqtsVersion: Option[String] = None
+  private var observedTestCount: Long = 0L
+
   override def receive: Receive = {
 
     case testSetResults: TestSetResults =>
       logger.info(s"Serializing results for TestSet: ${testSetResults.testSetRef.name} (${testSetResults.testSetRef.file})...")
+      if (observedXqtsVersion.isEmpty) {
+        observedXqtsVersion = Some(XQTSVersion.label(testSetResults.testSetRef.xqtsVersion))
+      }
+      observedTestCount += testSetResults.results.size
+
       val serializeIo: IO[Option[Throwable]] = dataDir
         .flatMap(dataFile(_, testSetResults.testSetRef.name))
         .flatMap(dataFileOutput(_)
@@ -89,8 +101,33 @@ class JUnitResultsSerializerActor(styleDir: Option[Path], outputDir: Path) exten
           logger.error(s"Could not aggregate results report. ${t.getMessage}", t)
       }
 
+      writeRunnerInfo()
+
       // notify the sender that we have completed serialization
       sender() ! FinishedSerialization
+  }
+
+  /**
+   * Emit `runner-info.xml` at the output directory root, capturing the runner
+   * JAR's build SHA + sha256 and the embedded `exist-core` version. Consumed
+   * by `compare-results.xslt` to surface runner-drift warnings.
+   *
+   * Failures here are logged but never propagated -- emitting metadata must
+   * not affect the run's exit status.
+   */
+  private def writeRunnerInfo(): Unit = {
+    val runInfo = RunnerInfo.RunInfo(
+      started = runStarted,
+      completed = Instant.now(),
+      xqtsVersion = observedXqtsVersion,
+      testCount = observedTestCount
+    )
+    RunnerInfo.write(outputDir, runInfo) match {
+      case Right(path) =>
+        logger.info(s"Wrote runner metadata to: ${path.toAbsolutePath}")
+      case Left(t) =>
+        logger.warn(s"Could not write runner-info.xml. ${t.getMessage}", t)
+    }
   }
 
   private def dataDir: IO[Path] = IO {

--- a/src/main/scala/org/exist/xqts/runner/RunnerInfo.scala
+++ b/src/main/scala/org/exist/xqts/runner/RunnerInfo.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2026  The eXist Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exist.xqts.runner
+
+import java.io.File
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.Properties
+import java.util.jar.{JarFile, Manifest}
+
+import scala.util.Try
+
+/**
+ * Captures metadata about the runner JAR build and the current XQTS run, and
+ * writes it to a sibling `runner-info.xml` in the output directory.
+ *
+ * Two consumers exist for this metadata:
+ *   1. `eXist-db/exist`'s `compare-results.xslt`, which surfaces a
+ *      `comparison-warning kind="runner-drift"` element when the previous and
+ *      current runs' runner JAR build SHAs (or the embedded `exist-core`
+ *      version) differ.
+ *   2. Future audit tooling that wants a deterministic record of which runner
+ *      build produced a given JUnit XML output dir.
+ *
+ * All fields gracefully degrade to `unknown="true"` when not available (e.g.,
+ * when the runner is started from `sbt run` rather than an assembled JAR).
+ *
+ * See https://github.com/eXist-db/exist/issues/6326 for the originating issue.
+ */
+object RunnerInfo {
+
+  private val NS = "http://exist-db.org/exist-xqts-runner/runner-info"
+
+  case class JarInfo(
+    gitSha: Option[String],
+    gitShaAbbrev: Option[String],
+    buildTag: Option[String],
+    buildVersion: Option[String],
+    builtTimestamp: Option[String],
+    builtBy: Option[String],
+    buildJdk: Option[String],
+    sha256: Option[String],
+    jarPath: Option[Path]
+  )
+
+  case class EmbeddedExistCoreInfo(
+    version: Option[String],
+    groupId: Option[String],
+    artifactId: Option[String],
+    pomPropertiesPath: Option[String]
+  )
+
+  case class RunInfo(
+    started: Instant,
+    completed: Instant,
+    xqtsVersion: Option[String],
+    testCount: Long
+  )
+
+  /**
+   * Locate the JAR file containing this class. Returns None when the runner is
+   * launched from a class directory (e.g. `sbt run`), which is the expected
+   * dev workflow.
+   */
+  private def runnerJarPath: Option[Path] = {
+    Try {
+      val cs = getClass.getProtectionDomain.getCodeSource
+      if (cs == null) None
+      else {
+        val url = cs.getLocation
+        if (url == null) None
+        else {
+          val f = new File(url.toURI)
+          if (f.isFile && f.getName.endsWith(".jar")) Some(f.toPath) else None
+        }
+      }
+    }.toOption.flatten
+  }
+
+  /** Read the runner JAR's MANIFEST.MF and compute its sha256. */
+  def collectJarInfo(): JarInfo = {
+    runnerJarPath match {
+      case Some(jarPath) =>
+        val manifest: Option[Manifest] = Try {
+          val jar = new JarFile(jarPath.toFile)
+          try Option(jar.getManifest) finally jar.close()
+        }.toOption.flatten
+
+        def attr(key: String): Option[String] =
+          manifest
+            .flatMap(m => Option(m.getMainAttributes.getValue(key)))
+            .map(_.trim)
+            .filter(_.nonEmpty)
+
+        val sha256 = Checksum.checksum(jarPath, Checksum.SHA256) match {
+          case Right(bytes) => Some(bytes.map(b => f"${b & 0xff}%02x").mkString)
+          case Left(_)      => None
+        }
+
+        JarInfo(
+          gitSha = attr("Git-Commit"),
+          gitShaAbbrev = attr("Git-Commit-Abbrev"),
+          buildTag = attr("Build-Tag"),
+          buildVersion = attr("Build-Version"),
+          builtTimestamp = attr("Build-Timestamp"),
+          builtBy = attr("Built-By"),
+          buildJdk = attr("Build-Jdk"),
+          sha256 = sha256,
+          jarPath = Some(jarPath)
+        )
+
+      case None =>
+        JarInfo(None, None, None, None, None, None, None, None, None)
+    }
+  }
+
+  /**
+   * Read embedded `exist-core` metadata from
+   * `META-INF/maven/org.exist-db/exist-core/pom.properties`. Works whether
+   * `exist-core` is a sibling JAR on the classpath (Maven appassembler layout)
+   * or shaded into the runner JAR (sbt-assembly fat-JAR layout) -- in both
+   * cases the resource is reachable via the runner's classloader.
+   */
+  def collectEmbeddedExistCoreInfo(): EmbeddedExistCoreInfo = {
+    val pomPath = "META-INF/maven/org.exist-db/exist-core/pom.properties"
+    Option(getClass.getClassLoader.getResourceAsStream(pomPath)) match {
+      case Some(is) =>
+        try {
+          val props = new Properties()
+          props.load(is)
+          EmbeddedExistCoreInfo(
+            version = Option(props.getProperty("version")),
+            groupId = Option(props.getProperty("groupId")),
+            artifactId = Option(props.getProperty("artifactId")),
+            pomPropertiesPath = Some(pomPath)
+          )
+        } finally is.close()
+      case None =>
+        EmbeddedExistCoreInfo(None, None, None, None)
+    }
+  }
+
+  /** Build the runner-info.xml document as a string. */
+  def render(jar: JarInfo, ec: EmbeddedExistCoreInfo, run: RunInfo): String = {
+    val sb = new StringBuilder
+    sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+    sb.append(s"""<runner-info xmlns="$NS">""").append('\n')
+
+    sb.append("    <runner-jar>\n")
+    sb.append(elem("git-sha", jar.gitSha))
+    sb.append(elem("git-sha-abbrev", jar.gitShaAbbrev))
+    sb.append(elem("build-tag", jar.buildTag))
+    sb.append(elem("build-version", jar.buildVersion))
+    sb.append(elem("built-timestamp", jar.builtTimestamp))
+    sb.append(elem("built-by", jar.builtBy))
+    sb.append(elem("build-jdk", jar.buildJdk))
+    sb.append(elem("sha256", jar.sha256))
+    sb.append(elem("jar-path", jar.jarPath.map(_.toAbsolutePath.toString)))
+    sb.append("    </runner-jar>\n")
+
+    sb.append("    <embedded-exist-core>\n")
+    sb.append(elem("version", ec.version))
+    sb.append(elem("group-id", ec.groupId))
+    sb.append(elem("artifact-id", ec.artifactId))
+    sb.append(elem("pom-properties-source", ec.pomPropertiesPath))
+    sb.append("    </embedded-exist-core>\n")
+
+    sb.append("    <run-info>\n")
+    sb.append(elem("started", Some(DateTimeFormatter.ISO_INSTANT.format(run.started))))
+    sb.append(elem("completed", Some(DateTimeFormatter.ISO_INSTANT.format(run.completed))))
+    sb.append(elem("xqts-version", run.xqtsVersion))
+    sb.append(elem("test-count", Some(run.testCount.toString)))
+    sb.append("    </run-info>\n")
+
+    sb.append("</runner-info>\n")
+    sb.toString
+  }
+
+  private def elem(name: String, value: Option[String]): String = value match {
+    case Some(v) if v.nonEmpty => s"        <$name>${escape(v)}</$name>\n"
+    case _                     => s"        <$name unknown=\"true\"/>\n"
+  }
+
+  private def escape(s: String): String =
+    s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+  /**
+   * Write `runner-info.xml` to the output directory root. Returns the path
+   * that was written, or a Throwable if the write failed.
+   */
+  def write(outputDir: Path, run: RunInfo): Either[Throwable, Path] = Try {
+    val target = outputDir.resolve("runner-info.xml")
+    Files.createDirectories(outputDir)
+    val xml = render(collectJarInfo(), collectEmbeddedExistCoreInfo(), run)
+    Files.writeString(target, xml)
+    target
+  }.toEither
+}


### PR DESCRIPTION
## Summary

Captures the runner JAR's git build SHA, sha256, and the embedded `exist-core` version into a sibling `runner-info.xml` written to the output directory root. The metadata is consumed by [`eXist-db/exist`'s `compare-results.xslt`](https://github.com/eXist-db/exist/blob/develop/exist-xqts/src/main/xslt/compare-results.xslt) to surface a `comparison-warning` element when two runs' runner builds differ.

Parent issue: https://github.com/eXist-db/exist/issues/6326 (mitigation A).
Companion eXist PR: https://github.com/eXist-db/exist/pull/<TBD-eXist-side>

## Why

The same eXist source can produce dramatically different XQTS results when run against two different runner JAR builds. Concrete data point from a 2026-05-09 investigation, identical eXist SHA both runs:

| | May 9 runner JAR | May 10 runner JAR (`applyVersionHint` cap-at-3.1 patch) |
|---|---|---|
| Pass rate | 90.9% (23,250/25,574) | **92.5% (24,081/26,014)** -- +831 tests |
| Total wallclock | 5,362s (89 min) | **215s (3m 35s)** -- 25x faster |

Without metadata in the output, CI's `compare-results` transform attributes those deltas to the PR's source change. It's wrong. This patch is the first half of making such drift directly attributable.

A second drift mode surfaced during PR #6331's perf-6322 investigation: locally-built runner JARs shade `exist-core`, so two runs of the same runner-source git SHA can still differ if assembled from different `exist-core` snapshots. `runner-info.xml` captures both signals (runner JAR's git-sha + sha256, and embedded `exist-core`'s version).

## What changed

- **New `RunnerInfo` helper** reads the runner JAR's `META-INF/MANIFEST.MF` for the fields already populated by `Compile / packageBin / packageOptions` (Git-Commit, Build-Tag, Build-Timestamp, ...), computes the JAR's sha256 via the existing `Checksum` utility, and reads the embedded exist-core's `META-INF/maven/org.exist-db/exist-core/pom.properties` for version + groupId + artifactId. All fields gracefully degrade to `unknown=\"true\"` when not available (e.g., when the runner is launched via `sbt run` from a class directory rather than an assembled JAR, or when a manifest field happens to be missing).
- **`JUnitResultsSerializerActor`** captures the run's start timestamp at actor construction and the xqts-version + test count from incoming `TestSetResults`, then writes `<output-dir>/runner-info.xml` during `FinalizeSerialization`. Failures are logged but never propagated -- emitting metadata must not affect the run's exit status.

### Sample output

```xml
<runner-info xmlns=\"http://exist-db.org/exist-xqts-runner/runner-info\">
    <runner-jar>
        <git-sha>1a5c00f3...</git-sha>
        <git-sha-abbrev>1a5c00f</git-sha-abbrev>
        <build-tag>v2.0.0-SNAPSHOT</build-tag>
        <build-version>N/A</build-version>
        <built-timestamp>20260510114215</built-timestamp>
        <built-by>ci</built-by>
        <build-jdk>21.0.5+11-LTS</build-jdk>
        <sha256>9c2d8e7f...</sha256>
        <jar-path>/.../exist-xqts-runner_2.13-2.0.0-SNAPSHOT.jar</jar-path>
    </runner-jar>
    <embedded-exist-core>
        <version>7.0.0-SNAPSHOT</version>
        <group-id>org.exist-db</group-id>
        <artifact-id>exist-core</artifact-id>
        <pom-properties-source>META-INF/maven/org.exist-db/exist-core/pom.properties</pom-properties-source>
    </embedded-exist-core>
    <run-info>
        <started>2026-05-10T11:32:15Z</started>
        <completed>2026-05-10T11:35:50Z</completed>
        <xqts-version>3.1</xqts-version>
        <test-count>26014</test-count>
    </run-info>
</runner-info>
```

## Test plan

- [x] \`sbt compile\` clean (warnings unchanged from baseline -- all in pre-existing files).
- [x] Companion XSLT side hand-tested against synthetic \`runner-info.xml\` files in 5 scenarios (SHAs differ, SHAs match, missing on one side, malformed, embedded-exist-core-only drift) -- see eXist-side PR.
- [ ] Smoke test: end-to-end XQTS run on next CI execution should produce \`runner-info.xml\` at the artifact root and round-trip through \`actions/upload-artifact\` automatically.

## Risk and rollback

The change is purely additive. Reverting removes \`runner-info.xml\` emission; the runner runs normally otherwise. The companion XSLT side degrades to a no-op when \`runner-info.xml\` is absent, so the two PRs can land in either order.