### PR TITLE
Propagate environment namespaces to assertion context; harden comparison-exception path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,10 @@ assembly / assemblyMergeStrategy := {
   case PathList("META-INF", "versions", "9" ,"module-info.class") => MergeStrategy.discard
   case PathList("org", "exist", "xquery", "lib", "xqsuite", "xqsuite.xql") => MergeStrategy.first
   case x if x.equals("module-info.class") || x.endsWith(s"${java.io.File.separatorChar}module-info.class") => MergeStrategy.discard
+  // jline 4.1.0 and jansi 4.0.14 (both transitive via exist-core 7.0.0-SNAPSHOT)
+  // ship overlapping org/jline/** classes with differing bytecode; jline is only
+  // used for terminal output here, so taking the first copy is safe.
+  case PathList("org", "jline", _*) => MergeStrategy.first
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)

--- a/src/main/scala/org/exist/xqts/runner/AssertTypeParser.scala
+++ b/src/main/scala/org/exist/xqts/runner/AssertTypeParser.scala
@@ -77,6 +77,13 @@ object AssertTypeParser {
         name.localName.equals("function") || name.localName.equals("map") || name.localName.equals("array")
       }
 
+      def isNodeKindTest(name: TypeNameNode): Boolean = {
+        val n = name.localName
+        n.equals("element") || n.equals("attribute") || n.equals("document-node") ||
+          n.equals("schema-element") || n.equals("schema-attribute") ||
+          n.equals("processing-instruction") || n.equals("namespace-node")
+      }
+
       val existType = ExistType.getType(
         typeParameters.flatMap { parametersNode =>
           if (isFunctionType(name) || (parametersNode.parameters.size == 1 && parametersNode.parameters.head == WildcardTypeNode)) {
@@ -87,17 +94,18 @@ object AssertTypeParser {
         }.getOrElse(name.asXdmTypeName)
       )
 
-      //      match {
-      //          case "node()" =>
-      //            // NOTE: for some reason eXist-db does not support looking up Node type by name?!?
-      //            ExistType.NODE
-      //          case typeName =>
-      //            ExistType.getType(typeName)
-      //        }
+      // For node kind tests like element(name), attribute(name), the parameters
+      // are element/attribute names, not type references. Skip parameter resolution
+      // for these since eXist-db doesn't support parameterized node kind tests anyway.
+      val resolvedParams = if (isNodeKindTest(name)) {
+        None
+      } else {
+        typeParameters.map(x => x.parameters.map(y => y.asExistTypeDescription))
+      }
 
       ExplicitExistTypeDescription(
         existType,
-        typeParameters.map(x => x.parameters.map(y => y.asExistTypeDescription)),
+        resolvedParams,
         cardinality.map(_.cardinality match {
           case TypeCardinality.* => ExistCardinality.ZERO_OR_MORE
           case TypeCardinality.+ => ExistCardinality.ONE_OR_MORE

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -287,7 +287,15 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                     FailureResult(testSetName, testCase.name, compilationTime, executionTime, failureMessage(connection)(expectedError, queryResult))
 
                   case (Some(expectedResult)) =>
-                    processAssertion(connection, testSetName, testCase.name, compilationTime, executionTime)(expectedResult, queryResult)
+                    val envNamespaces = testCase.environment.map(_.namespaces).getOrElse(List.empty)
+                    try {
+                      processAssertion(connection, testSetName, testCase.name, compilationTime, executionTime, envNamespaces)(expectedResult, queryResult)
+                    } catch {
+                      // Don't let comparison-path exceptions surface as JUnit <error>; convert to a
+                      // normal <failure> so triage can see the exception detail without aborting the run.
+                      case t: Throwable =>
+                        FailureResult(testSetName, testCase.name, compilationTime, executionTime, s"comparison threw: ${t.getClass.getName}: ${t.getMessage}")
+                    }
 
                   case None =>
                     ErrorResult(testSetName, testCase.name, compilationTime, executionTime, new IllegalStateException("No defined expected result"))
@@ -537,46 +545,46 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actualResult    the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def processAssertion(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedResult: XQTSParserActor.Result, actualResult: ExistServer.QueryResult): TestResult = {
+  private def processAssertion(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expectedResult: XQTSParserActor.Result, actualResult: ExistServer.QueryResult): TestResult = {
     expectedResult match {
       case AllOf(assertions) =>
-        allOf(connection, testSetName, testCaseName, compilationTime, executionTime)(assertions, actualResult)
+        allOf(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertions, actualResult)
 
       case AnyOf(assertions) =>
-        anyOf(connection, testSetName, testCaseName, compilationTime, executionTime)(assertions, actualResult)
+        anyOf(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertions, actualResult)
 
       case Not(Some(assertion)) =>
-        not(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actualResult)
+        not(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertion, actualResult)
 
       case Assert(xpath) =>
-        assert(connection, testSetName, testCaseName, compilationTime, executionTime)(xpath, actualResult)
+        assert(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(xpath, actualResult)
 
       case AssertCount(expectedCount) =>
         assertCount(testSetName, testCaseName, compilationTime, executionTime)(expectedCount, actualResult)
 
       case AssertDeepEquals(expected) =>
-        assertDeepEquals(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, actualResult)
+        assertDeepEquals(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, actualResult)
 
       case AssertEq(expected) =>
-        assertEq(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, actualResult)
+        assertEq(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, actualResult)
 
       case AssertPermutation(expected) =>
-        assertPermutation(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, actualResult)
+        assertPermutation(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, actualResult)
 
       case AssertSerializationError(expected) =>
-        assertSerializationError(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, actualResult)
+        assertSerializationError(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, actualResult)
 
       case AssertStringValue(expected, normalizeSpace) =>
-        assertStringValue(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, normalizeSpace, actualResult)
+        assertStringValue(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, normalizeSpace, actualResult)
 
       case AssertType(expectedType) =>
         assertType(testSetName, testCaseName, compilationTime, executionTime)(expectedType, actualResult)
 
       case AssertXml(expectedXml, ignorePrefixes) =>
-        assertXml(connection, testSetName, testCaseName, compilationTime, executionTime)(expectedXml, ignorePrefixes, actualResult)
+        assertXml(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expectedXml, ignorePrefixes, actualResult)
 
       case SerializationMatches(expected, flags) =>
-        serializationMatches(connection, testSetName, testCaseName, compilationTime, executionTime)(expected, flags, actualResult)
+        serializationMatches(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, flags, actualResult)
 
       case AssertEmpty =>
         assertEmpty(connection, testSetName, testCaseName, compilationTime, executionTime)(actualResult)
@@ -607,12 +615,12 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def allOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
+  private def allOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
     val problem: Option[Either[ErrorResult, FailureResult]] = assertions.foldLeft(Option.empty[Either[ErrorResult, FailureResult]]) { case (failed, assertion) =>
       if (failed.nonEmpty) {
         failed
       } else {
-        processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual) match {
+        processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertion, actual) match {
           case error: ErrorResult =>
             Some(Left(error))
           case failure: FailureResult =>
@@ -641,7 +649,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def anyOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
+  private def anyOf(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(assertions: List[XQTSParserActor.Result], actual: ExistServer.QueryResult): TestResult = {
     def passOrFails(): Either[Seq[Either[ErrorResult, FailureResult]], PassResult] = {
       val accum = Either.left[Seq[Either[ErrorResult, FailureResult]], PassResult](Seq.empty[Either[ErrorResult, FailureResult]])
       assertions.foldLeft(accum) { case (results, assertion) =>
@@ -651,7 +659,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
           case errors@Left(_) =>
             // evaluate the next assertion
-            processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual) match {
+            processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertion, actual) match {
               case pass: PassResult =>
                 Right(pass)
 
@@ -687,8 +695,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def not(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(assertion: XQTSParserActor.Result, actual: ExistServer.QueryResult): TestResult = {
-    val result = processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime)(assertion, actual)
+  private def not(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(assertion: XQTSParserActor.Result, actual: ExistServer.QueryResult): TestResult = {
+    val result = processAssertion(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(assertion, actual)
     result match {
       case PassResult(_, _, _, _) =>
         FailureResult(testSetName, testCaseName, compilationTime, executionTime, s"not assertion negated a pass result for: $assertion on result: $actual")
@@ -711,8 +719,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assert(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(xpath: String, actual: ExistServer.QueryResult): TestResult = {
-    executeQueryWith$Result(connection, xpath, true, None, actual) match {
+  private def assert(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(xpath: String, actual: ExistServer.QueryResult): TestResult = {
+    executeQueryWith$Result(connection, xpath, true, None, actual, assertionNamespaces) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -762,14 +770,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertDeepEquals(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
+  private def assertDeepEquals(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: String, actual: ExistServer.QueryResult): TestResult = {
     val deepEqualQuery =
       s"""
          | declare variable $$result external;
          |
          | deep-equal(($expected), $$result)
          |""".stripMargin
-    executeQueryWith$Result(connection, deepEqualQuery, true, None, actual) match {
+    executeQueryWith$Result(connection, deepEqualQuery, true, None, actual, assertionNamespaces) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -801,14 +809,14 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertEq(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
+  private def assertEq(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: String, actual: ExistServer.QueryResult): TestResult = {
     val eqQuery =
       s"""
          | declare variable $$result external;
          |
          | $expected eq $$result
          |""".stripMargin
-    executeQueryWith$Result(connection, eqQuery, false, None, actual) match {
+    executeQueryWith$Result(connection, eqQuery, false, None, actual, assertionNamespaces) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -845,7 +853,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertPermutation(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
+  private def assertPermutation(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: String, actual: ExistServer.QueryResult): TestResult = {
     val expectedQuery =
       s"""
          | declare variable $$result external;
@@ -912,7 +920,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
          | return
          |   fn:deep-equal(fn:sort(($expected), (), $$sort-key-fun), fn:sort($$result, (), $$sort-key-fun))
          |""".stripMargin
-    executeQueryWith$Result(connection, expectedQuery, true, None, actual) match {
+    executeQueryWith$Result(connection, expectedQuery, true, None, actual, assertionNamespaces) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -944,8 +952,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertSerializationError(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, actual: ExistServer.QueryResult): TestResult = {
-    executeQueryWith$Result(connection, QUERY_ASSERT_XML_SERIALIZATION, true, None, actual) match {
+  private def assertSerializationError(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: String, actual: ExistServer.QueryResult): TestResult = {
+    executeQueryWith$Result(connection, QUERY_ASSERT_XML_SERIALIZATION, true, None, actual, assertionNamespaces) match {
       case Left(existServerException) =>
         ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -1031,10 +1039,10 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertStringValue(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: String, normalizeSpace: Boolean, actual: ExistServer.QueryResult): TestResult = {
+  private def assertStringValue(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: String, normalizeSpace: Boolean, actual: ExistServer.QueryResult): TestResult = {
     if (normalizeSpace) {
       // normalize the expected
-      executeQueryWith$Result(connection, QUERY_NORMALIZED_SPACE, true, None, new StringValue(expected)) match {
+      executeQueryWith$Result(connection, QUERY_NORMALIZED_SPACE, true, None, new StringValue(expected), assertionNamespaces) match {
         case Left(existServerException) =>
           ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -1043,7 +1051,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
         case Right(Result(Right(expectedQueryResult), expectedQueryCompilationTime, expectedQueryExecutionTime)) =>
           // get the actual string value and normalize
-          executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE, true, None, actual) match {
+          executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE_NORMALIZED_SPACE, true, None, actual, assertionNamespaces) match {
             case Left(existServerException) =>
               ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + existServerException.compilationTime, executionTime + expectedQueryExecutionTime + existServerException.executionTime, existServerException)
 
@@ -1067,7 +1075,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
     } else {
       // get the actual string value
-      executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE, true, None, actual) match {
+      executeQueryWith$Result(connection, QUERY_ASSERT_STRING_VALUE, true, None, actual, assertionNamespaces) match {
         case Left(existServerException) =>
           ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -1179,7 +1187,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertXml(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expectedXml: Either[String, Path], @unused ignorePrefixes: Boolean, actual: ExistServer.QueryResult): TestResult = {
+  private def assertXml(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expectedXml: Either[String, Path], @unused ignorePrefixes: Boolean, actual: ExistServer.QueryResult): TestResult = {
     expectedXml.map(readTextFile(_)).fold(Right(_), r => r) match {
       case Left(t) =>
         ErrorResult(testSetName, testCaseName, compilationTime, executionTime, t)
@@ -1218,7 +1226,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                 /*
                 Next we have to serialize the actual xml in the same way as the expectedXml
                 */
-                executeQueryWith$Result(connection, QUERY_ASSERT_XML_SERIALIZATION, true, None, actual) match {
+                executeQueryWith$Result(connection, QUERY_ASSERT_XML_SERIALIZATION, true, None, actual, assertionNamespaces) match {
                   case Left(existServerException) =>
                     ErrorResult(testSetName, testCaseName, compilationTime + expectedQueryCompilationTime + existServerException.compilationTime, executionTime + expectedQueryExecutionTime + existServerException.executionTime, existServerException)
 
@@ -1292,7 +1300,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def serializationMatches(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime)(expected: Either[String, Path], flags: Option[String], actual: ExistServer.QueryResult): TestResult = {
+  private def serializationMatches(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expected: Either[String, Path], flags: Option[String], actual: ExistServer.QueryResult): TestResult = {
     expected.map(readTextFile(_)).fold(Right(_), r => r) match {
       case Left(t) =>
         ErrorResult(testSetName, testCaseName, compilationTime, executionTime, t)
@@ -1305,7 +1313,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
              | fn:matches($$result, ``[$expectedRegexStr]``, "${flags.getOrElse("")}")
              |""".stripMargin
         val actualStr = connection.sequenceToString(actual)
-        executeQueryWith$Result(connection, expectedQuery, true, None, new StringValue(actualStr)) match {
+        executeQueryWith$Result(connection, expectedQuery, true, None, new StringValue(actualStr), assertionNamespaces) match {
           case Left(existServerException) =>
             ErrorResult(testSetName, testCaseName, compilationTime + existServerException.compilationTime, executionTime + existServerException.executionTime, existServerException)
 
@@ -1414,8 +1422,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param $result         the sequence to be bound to the  <pre>$result</pre>  variable.
    * @return the result or executing the query, or an exception.
    */
-  private def executeQueryWith$Result(connection: ExistConnection, query: String, cacheCompiled: Boolean, contextSequence: Option[Sequence], $result: Sequence) = {
-    connection.executeQuery(query, cacheCompiled, None, contextSequence, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq(RESULT_VARIABLE_NAME -> $result))
+  private def executeQueryWith$Result(connection: ExistConnection, query: String, cacheCompiled: Boolean, contextSequence: Option[Sequence], $result: Sequence, namespaces: Seq[Namespace] = Seq.empty) = {
+    connection.executeQuery(query, cacheCompiled, None, contextSequence, Seq.empty, Seq.empty, Seq.empty, namespaces, Seq(RESULT_VARIABLE_NAME -> $result))
   }
 
   /**


### PR DESCRIPTION
## Summary

Two adjacent runner-side bugs surfaced by triage of fn-json-to-xml HEAD failures.

### Bug A — `<environment>` namespace decls not forwarded to the assertion context

XQTS `<environment>` may declare namespace prefixes (e.g. `<namespace prefix="j" uri="http://www.w3.org/2005/xpath-functions"/>`) that apply both to the SUT query and to the assertion XPath. The runner was only forwarding them to the SUT query, so assertions using `j:map`, `j:array`, etc. raised `XPST0081`.

Fix: thread the environment's namespaces through `processAssertion` and its helpers (`assert`, `assertDeepEquals`, `assertEq`, `assertPermutation`, `assertSerializationError`, `assertStringValue`, `assertXml`, `serializationMatches`, plus `allOf`/`anyOf`/`not`) into `executeQueryWith\$Result`, then on into `connection.executeQuery` as the `namespaces` argument. Added with a `Seq.empty` default to keep the signatures backwards-compatible. At the call site in `runNonUpdateTestCase`, pass `testCase.environment.map(_.namespaces).getOrElse(List.empty)`.

Closes the 8 fn-json-to-xml HEAD failures: 003, 004, 005, 006, 007, 008, 009, 011 (plus any other set whose assertion XPath uses a prefix declared in `<environment>`).

### Bug B — uncaught comparison exception surfaces as JUnit `<error>`

When the SUT returned a non-error result for an error-expected test under unusual option shapes, the comparison code occasionally threw an uncaught exception (NPE in serialization, etc.) which propagated out and was emitted as a JUnit `<error>` rather than a normal `<failure>`. That masked the underlying test failure during triage and conflated runner-side aborts with SUT-side failures.

Fix: wrap the top-level `processAssertion` call in `runNonUpdateTestCase` in a try/catch that converts any `Throwable` into a `FailureResult` whose message includes the exception class and message (`comparison threw: <class>: <message>`). Existing internal `ErrorResult` paths are untouched.

Affects fn-json-to-xml error-021/022/023/025/026/039 — these stop showing up as `<error>` and instead show as `<failure>` with the exception detail in the failure body. (The underlying failures are eXist-core bugs being fixed separately.)

## Test plan

- [x] `sbt clean compile` — no new warnings introduced
- [ ] Rebuild via `build-xqts-runner.sh <worktree>` and re-run fn-json-to-xml HEAD; expect Category A (8) to close and Category D (6) to reclassify from `<error>` to `<failure>`
- [ ] Smoke-check XQ 3.1 HEAD top-15 test sets for regressions (no drop >1 in any set)