### PR TITLE
[bugfix] applyVersionHint: cap "+"-form spec deps at "3.1" for XQTS 3.1 / HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ The results of executing the XQTS will be formatted as JUnit test output.
 * An HTML aggregate report summary will be written to `target/junit/html/index.html`.
 
 
+## XQuery version hints
+
+Many XQTS test queries omit an `xquery version "..."` prolog declaration and rely on the harness to run them under the right language version. eXist applies version-specific parsing and semantics, so the runner prepends a version declaration derived from each test case's `spec` dependency in the XQTS catalog.
+
+Three similar-looking tokens are involved. They are **not** the same thing:
+
+| Token | Kind | Meaning |
+|-------|------|---------|
+| `XQ10`, `XQ30`, `XQ31`, `XQ40` | XQTS catalog `spec` dependency value | the XQuery language version(s) a test targets |
+| `XQ31+` (trailing `+`) | XQTS catalog `spec` dependency value | "this version **or any later**" |
+| `XQTS_3_1`, `XQTS_HEAD` | the runner's `--xqts-version` selector | which **test suite** is being run |
+| `"3.1"`, `"4.0"` | XQuery version string | what actually gets prepended to the query |
+
+The runner chooses the prepended version as follows:
+
+* If the query already declares a version (`xquery version` / `module namespace`), it is left unchanged.
+* If a `spec` dependency names `XQ40` explicitly, prepend `"4.0"`.
+* If a `spec` dependency uses the `+` ("or later") form, prepend the **floor of the suite being run**: `"3.1"` for `XQTS_3_1` and `XQTS_HEAD`, otherwise `"4.0"`.
+* Otherwise prepend the highest strict (non-`+`) spec: `XQ31` → `"3.1"`, `XQ30` → `"3.0"`, `XQ10` → `"1.0"`.
+* If there is no XQuery `spec` dependency, the query is left unchanged.
+
+### Why cap the `+` form at the suite floor?
+
+A dependency such as `XQ31+` marks a test as valid for XQuery 3.1 and every later version. When measuring XQTS 3.1 (`XQTS_3_1`) or the live community-maintained HEAD suite (`XQTS_HEAD`, which tracks the final XQuery 3.1 Recommendation plus corrections), we want those tests run as 3.1, not 4.0. Prepending `"4.0"` would ask the engine to parse them as XQuery 4.0, and an engine that does not accept `xquery version "4.0"` — as is the case for eXist-db's current `develop` HEAD — rejects them at parse time, turning would-be passes into spurious parse failures. Capping the `+` form at `"3.1"` for the 3.1-era suites keeps those tests running under the version they were authored for.
+
+
 ## Application Architecture
 The application is constructed using [Akka](https://akka.io), and as such makes use of Actors to perform many tasks in parallel; This hopefully speeds up the process of running the XQTS which includes many test cases.
 When the Application first executes, it will check for a local copy of the XQTS in a sub-directory named `work`, if it cannot find a local copy of the XQTS then it will download it from the W3C.

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -209,22 +209,20 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
-   * Prepend `xquery version "..."` to the test query, picking the right version
-   * from the test's spec dependencies and the XQTS suite being run.
+   * Prepend an `xquery version "..."` declaration to a test query so eXist
+   * applies the correct language semantics. The version is chosen from the
+   * test's `spec` dependency and the suite being run.
    *
-   * Tests need a version declaration so eXist applies version-specific semantics.
-   * Strict deps like `XQ10 XQ30 XQ31` (no plus form) mark tests authored before
-   * XQuery 4.0; running them as XQ4 trips changed rules. The `+` form means
-   * "this version or any later" — for XQ 3.1 / live HEAD measurements we cap
-   * it at "3.1" so engines that don't accept `xquery version "4.0"` (develop's
-   * exist-core) don't reject `+`-form tests at parse time.
+   * Selection by `spec`-dependency input (see the README "XQuery version hints"
+   * section for the full rationale and a glossary of the easily-confused
+   * `XQ31` / `XQTS_3_1` / `"3.1"` tokens):
    *
-   *   - If the query already declares a version, leave it alone.
-   *   - If a spec dep names `XQ40` explicitly, prepend "4.0".
-   *   - If a spec dep uses the `+` form, prepend the suite's own floor:
-   *     "3.1" for XQTS_3_1 / XQTS_HEAD, "4.0" otherwise.
-   *   - Otherwise, pick the highest strict spec (XQ31 > XQ30 > XQ10).
-   *   - If no XQ spec dep exists, leave unchanged.
+   *   - `XQ40`                        -> prepend `"4.0"`
+   *   - `XQ31+` (any `+`, "or later") -> the suite floor: `"3.1"` for
+   *                                      `XQTS_3_1` / `XQTS_HEAD`, else `"4.0"`
+   *   - `XQ31` / `XQ30` / `XQ10`      -> that exact version (highest wins)
+   *   - no `spec` dependency, or the query already declares a version
+   *                                   -> unchanged
    */
   private def applyVersionHint(query: String, deps: Seq[Dependency], xqtsVersion: XQTSVersion): String = {
     if (query.contains("xquery version") || query.contains("module namespace")) {

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -184,21 +184,23 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
     case RunTestCaseInternal(RunTestCase(testSetRef, testCase, manager), resolvedEnvironment) =>
       manager ! RunningTestCase(testSetRef, testCase.name)
       // actually run the test case!
-      val result = runTestCaseWithExist(testSetRef.name, testCase, resolvedEnvironment)
+      val result = runTestCaseWithExist(testSetRef.xqtsVersion, testSetRef.name, testCase, resolvedEnvironment)
       manager ! RanTestCase(testSetRef, result)
   }
 
   /**
    * Execute an XQTS test-case against eXist-db.
    *
+   * @param xqtsVersion         the XQTS version being run (used to pick a default
+   *                            `xquery version` for `+`-form spec deps).
    * @param testSetName         the name of the test-set of which the test-case is a part.
    * @param testCase            the test-case to execute.
    * @param resolvedEnvironment the environment resources for the test-case.
    * @return the result of executing the XQTS test-case.
    */
-  private def runTestCaseWithExist(testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
+  private def runTestCaseWithExist(xqtsVersion: XQTSVersion, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
     try {
-      runTestCase(existServer.getConnection(), testSetName, testCase, resolvedEnvironment)
+      runTestCase(existServer.getConnection(), xqtsVersion, testSetName, testCase, resolvedEnvironment)
     } catch {
       case e: java.lang.OutOfMemoryError =>
         System.err.println(s"OutOfMemoryError: $testSetName ${testCase.name}")
@@ -207,21 +209,71 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   }
 
   /**
+   * Prepend `xquery version "..."` to the test query, picking the right version
+   * from the test's spec dependencies and the XQTS suite being run.
+   *
+   * Tests need a version declaration so eXist applies version-specific semantics.
+   * Strict deps like `XQ10 XQ30 XQ31` (no plus form) mark tests authored before
+   * XQuery 4.0; running them as XQ4 trips changed rules. The `+` form means
+   * "this version or any later" — for XQ 3.1 / live HEAD measurements we cap
+   * it at "3.1" so engines that don't accept `xquery version "4.0"` (develop's
+   * exist-core) don't reject `+`-form tests at parse time.
+   *
+   *   - If the query already declares a version, leave it alone.
+   *   - If a spec dep names `XQ40` explicitly, prepend "4.0".
+   *   - If a spec dep uses the `+` form, prepend the suite's own floor:
+   *     "3.1" for XQTS_3_1 / XQTS_HEAD, "4.0" otherwise.
+   *   - Otherwise, pick the highest strict spec (XQ31 > XQ30 > XQ10).
+   *   - If no XQ spec dep exists, leave unchanged.
+   */
+  private def applyVersionHint(query: String, deps: Seq[Dependency], xqtsVersion: XQTSVersion): String = {
+    if (query.contains("xquery version") || query.contains("module namespace")) {
+      return query
+    }
+    val specDeps = deps.filter(d => d.`type` == DependencyType.Spec && d.satisfied)
+    if (specDeps.isEmpty) {
+      return query
+    }
+    val acceptsAnyLater = specDeps.exists(_.value.contains("+"))
+    val specs = specDeps.flatMap(_.value.split(' ').toSeq).filter(_.nonEmpty).toSet
+    val plusFormVersion = xqtsVersion match {
+      case XQTS_3_1  => "3.1"
+      case XQTS_HEAD => "3.1"  // HEAD = live qt3tests master = final XQ 3.1 Rec + corrections
+      case _         => "4.0"
+    }
+    val version =
+      if (specs.contains("XQ40")) Some("4.0")
+      else if (acceptsAnyLater) Some(plusFormVersion)
+      else if (specs.contains("XQ31")) Some("3.1")
+      else if (specs.contains("XQ30")) Some("3.0")
+      else if (specs.contains("XQ10")) Some("1.0")
+      else None
+    version match {
+      case Some(v) => "xquery version \"" + v + "\";\n" + query
+      case None    => query
+    }
+  }
+
+  /**
    * Run's an XQTS test-case against eXist-db.
    *
    * @param connection          a connection to an eXist-db server.
+   * @param xqtsVersion         the XQTS version being run (used to pick a default
+   *                            `xquery version` for `+`-form spec deps).
    * @param testSetName         the name of the test-set of which the test-case is a part.
    * @param testCase            the test-case to execute.
    * @param resolvedEnvironment the environment resources for the test-case.
    * @return the result of executing the XQTS test-case.
    */
   @throws(classOf[OutOfMemoryError])
-  private def runTestCase(connection: ExistConnection, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
+  private def runTestCase(connection: ExistConnection, xqtsVersion: XQTSVersion, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
     testCase.test match {
       case Some(test) =>
 
-        // get the XQuery to execute
-        val queryString: String = test.map(_ => resolvedEnvironment.resolvedQuery.get).merge
+        // get the XQuery to execute, prepending a version declaration when the
+        // test's spec dependencies indicate a version older than the runner default.
+        val rawQuery: String = test.map(_ => resolvedEnvironment.resolvedQuery.get).merge
+        val queryString = applyVersionHint(rawQuery, testCase.dependencies, xqtsVersion)
 
         // get the static baseURI for the XQuery
         val baseUri = testCase.environment


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

XQTS tests need a version declaration so eXist applies version-specific semantics. The runner was previously hardcoding `xquery version "4.0"` for every `+`-form spec dep (`XQ31+`, `XQ40+`), which `develop`'s `exist-core` rejects at parse time because the 4.0 parser flag isn't on `develop` yet. On the live XQTS HEAD catalog that produced **5,697 spurious XQST0031 failures**, masking the real XQ 3.1 conformance picture.

This patch threads the active `TestSetRef.xqtsVersion` through to a new `applyVersionHint` helper and picks the prepended version per-suite:

|                                | Prepended version |
|--------------------------------|-------------------|
| Explicit `XQ40` spec dep       | `"4.0"`           |
| `+` form, `XQTS_3_1` / `XQTS_HEAD` | `"3.1"`       |
| `+` form, other suite          | `"4.0"`           |
| Strict `XQ31` / `XQ30` / `XQ10` | as declared      |
| No XQ spec dep                 | unchanged         |

## Impact

Measured on `develop@4f09d0accc` against `qt3tests` master `@83993587`:

| Runner state                  | Pass rate                |
|-------------------------------|--------------------------|
| HEAD + default (`+` → `"4.0"`) | 71.4% (22,050/30,872)   |
| HEAD + cap-3.1 (this PR)      | **90.5% (28,258/31,224)** |

90.5% is the canonical "XQ 3.1 conformance on the final spec" baseline for the eXist 7.0 release. Tests that explicitly declare an `XQ4` dependency are unaffected — the `specs.contains("XQ40")` branch keeps prepending `"4.0"` for those.

## Relationship to #50

Supersedes #50. The original branch was based on `feature/qt4-xquery-update` and carried ~25 unrelated commits (QT4 suite, XQFTTS, batch runner, etc.) that should ride with #49. This narrow version targets `develop` directly and contains only the `applyVersionHint` change — appropriate for the eXist 7.0 XQ 3.1 conformance focus before today's beta freeze.

## Test plan

- [x] `sbt compile` clean
- [ ] Re-run XQ 3.1 / HEAD against `develop`; expect ~90.5% pass rate, no regressions in tests declaring explicit `XQ40`