### PR TITLE
Fix source URI resolution and satisfied=false dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,8 @@ libraryDependencies ++= {
 
     "org.slf4j" % "slf4j-api" % "2.0.17",
     "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.25.2" % "runtime",
+
+    "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   )
 }
 

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -391,7 +391,9 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
   private def getDynamicContextAvailableDocuments(connection: ExistConnection)(testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): Either[ExistServerException, List[(String, DocumentImpl)]] = {
     val initAccum: Either[ExistServerException, List[(String, DocumentImpl)]] = Right(List.empty)
     testCase.environment
-      .map(env => env.sources.filter(source => (source.role.isEmpty || source.role.filter(Role.isContextItem(_)).nonEmpty) && source.uri.nonEmpty))
+      // a source with a uri is retrievable via fn:doc even when it also fills a role,
+      // e.g. fn-transform-20 binds $staticbaseuri and resolves it by stylesheet-location
+      .map(env => env.sources.filter(_.uri.nonEmpty))
       .getOrElse(List.empty)
       .foldLeft(initAccum) { case (accum, x) =>
         accum match {
@@ -496,7 +498,9 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
                 .flatMap(role => resolvedEnvironment.resolvedSources.find(_.path == x.file)
                   .map(resolvedSource => (role, resolvedSource.data, resolvedSource.path))
                   .map { case (role, data, path) => SAXParser.parseXml(data).map(doc => {
-                    doc.setDocumentURI(path.toUri().toString())
+                    // prefer the URI the test declares for the source; fall back to the
+                    // location it was loaded from only when the test does not declare one
+                    doc.setDocumentURI(x.uri.getOrElse(path.toUri().toString()))
                     (role.asInstanceOf[ExternalVariableRole].name, doc)
                   }
                   )

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -438,13 +438,20 @@ object XQTSParserActor {
       }
     }
 
+    /**
+     * A dependency is met when the availability of what it names matches its
+     * `satisfied` flag. `satisfied="false"` therefore inverts the test: the
+     * test-case applies only where the dependency is *not* available.
+     */
     def allMissing(test: String => Missed, required: Seq[Dependency]): Missing = {
       required.foldLeft(Seq.empty[String]) { case (accum, x) =>
-        test(x.value)
-          .filter(_ => x.satisfied)
-          .map(missed => s"${x.`type`.xqtsName}=${missed}")
-          .map(_ +: accum)
-          .getOrElse(accum)
+        val available = test(x.value).isEmpty
+        if (available == x.satisfied) {
+          accum
+        } else {
+          val describe = s"${x.`type`.xqtsName}=${x.value}"
+          (if (x.satisfied) describe else s"${describe},satisfied=false") +: accum
+        }
       }
     }
 

--- a/src/test/scala/org/exist/xqts/runner/XQTSParserActorSpec.scala
+++ b/src/test/scala/org/exist/xqts/runner/XQTSParserActorSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2018  The eXist Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exist.xqts.runner
+
+import org.exist.xqts.runner.XQTSParserActor.Feature.Feature
+import org.exist.xqts.runner.XQTSParserActor.Spec.Spec
+import org.exist.xqts.runner.XQTSParserActor.XmlVersion.XmlVersion
+import org.exist.xqts.runner.XQTSParserActor.XsdVersion.XsdVersion
+import org.exist.xqts.runner.XQTSParserActor._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class XQTSParserActorSpec extends AnyWordSpec with Matchers {
+
+  private val enabledFeatures: Set[Feature] = Set(Feature.HigherOrderFunctions)
+  private val enabledSpecs: Set[Spec] = Set(Spec.XQ31)
+  private val enabledXmlVersions: Set[XmlVersion] = Set(XmlVersion.XML10)
+  private val enabledXsdVersions: Set[XsdVersion] = Set(XsdVersion.XSD10)
+
+  private def missing(dependencies: Dependency*): Missing =
+    missingDependencies(dependencies, enabledFeatures, enabledSpecs, enabledXmlVersions, enabledXsdVersions)
+
+  private def feature(value: String, satisfied: Boolean) =
+    Dependency(DependencyType.Feature, value, satisfied)
+
+  "missingDependencies" when {
+
+    "the dependency must be satisfied" should {
+
+      "be met when the feature is enabled" in {
+        missing(feature("higherOrderFunctions", satisfied = true)) shouldBe empty
+      }
+
+      "be unmet when the feature is not enabled" in {
+        missing(feature("staticTyping", satisfied = true)) should contain only "feature=staticTyping"
+      }
+    }
+
+    // XQTS uses satisfied="false" to mean "this test only applies where the
+    // dependency is absent", e.g. require-higher-order-function-1-ns asserts
+    // that an error is raised when higher order functions are unsupported.
+    "the dependency must not be satisfied" should {
+
+      "be unmet when the feature is enabled" in {
+        missing(feature("higherOrderFunctions", satisfied = false)) should
+          contain only "feature=higherOrderFunctions,satisfied=false"
+      }
+
+      "be met when the feature is not enabled" in {
+        missing(feature("staticTyping", satisfied = false)) shouldBe empty
+      }
+    }
+
+    "inverting non-feature dependencies" should {
+
+      "report an enabled spec as unmet when it must not be satisfied" in {
+        missing(Dependency(DependencyType.Spec, "XQ31", satisfied = false)) should
+          contain only "spec=XQ31,satisfied=false"
+      }
+
+      "report a disabled spec as met when it must not be satisfied" in {
+        missing(Dependency(DependencyType.Spec, "XQ10", satisfied = false)) shouldBe empty
+      }
+
+      "report an enabled xsd-version as unmet when it must not be satisfied" in {
+        missing(Dependency(DependencyType.XsdVersion, "1.0", satisfied = false)) should
+          contain only "xsd-version=1.0,satisfied=false"
+      }
+
+      "report an enabled xml-version as unmet when it must not be satisfied" in {
+        missing(Dependency(DependencyType.XmlVersion, "1.0", satisfied = false)) should
+          contain only "xml-version=1.0,satisfied=false"
+      }
+    }
+
+    "given several dependencies" should {
+
+      "collect every unmet dependency" in {
+        missing(
+          feature("higherOrderFunctions", satisfied = true),
+          feature("staticTyping", satisfied = true),
+          Dependency(DependencyType.Spec, "XQ10", satisfied = true)
+        ) should contain theSameElementsAs Seq("feature=staticTyping", "spec=XQ10")
+      }
+
+      "be met when all dependencies hold" in {
+        missing(
+          feature("higherOrderFunctions", satisfied = true),
+          feature("staticTyping", satisfied = false),
+          Dependency(DependencyType.Spec, "XQ31", satisfied = true),
+          Dependency(DependencyType.XmlVersion, "1.0", satisfied = true),
+          Dependency(DependencyType.XsdVersion, "1.0", satisfied = true)
+        ) shouldBe empty
+      }
+    }
+
+    "a spec dependency names several alternatives" should {
+
+      "be met when any alternative is enabled" in {
+        missing(Dependency(DependencyType.Spec, "XQ10 XQ31", satisfied = true)) shouldBe empty
+      }
+
+      "be met when an open ended range covers an enabled spec" in {
+        missing(Dependency(DependencyType.Spec, "XQ30+", satisfied = true)) shouldBe empty
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reimplements the three fixes from #34 (@alanpaxton, 2022) against current `develop`. That PR still identifies real bugs, but two of its three commits no longer apply cleanly and two solve the problem in a heavier way than necessary. Credit for finding all three goes there; this branch is a fresh, minimal implementation with tests.

## 1. Any source with a `uri` is retrievable via `fn:doc`

`getDynamicContextAvailableDocuments` excluded sources whose role was an external variable. But a source can both fill a role *and* be reachable by URI — `fn-transform-20`:

```xml
<source role="$staticbaseuri" file="transform/staticbaseuri.xsl"
        uri="http://www.w3.org/fots/fn/transform/staticbaseuri.xsl"/>
```

never reads `$staticbaseuri`; it resolves the stylesheet by passing that URI as `fn:transform`'s `stylesheet-location`. The catalog schema's `uri` documentation agrees: "For source documents, the URI can be used in a call to the `doc()` function."

Fixes `fn-transform-20` and `fn-transform-21`. Exactly four test cases in the suite have `role="$var"` plus a `uri` (20, 21, 41, 42).

## 2. Honour a source's declared document URI

The bound variable's document URI was always the path it was loaded from, never the `uri` the test declares.

**This currently has no observable effect.** #34 claims it fixes `fn-transform-42`, and it does not. That test passes the source to `fn:transform` as `stylesheet-node` and asserts its static base URI; eXist derives *no* static base URI from a stylesheet node's document URI, so the result is an empty `<x/>` and the test still fails. Verified by building with fixes 1+3 only: zero test-case differences. The runner side is nevertheless correct and is a prerequisite for fixing this in eXist. Filed separately.

## 3. `satisfied="false"` dependencies were vacuously met

`allMissing` discarded a dependency when `satisfied="false"` instead of inverting it. But `satisfied="false"` means *the test only applies where the dependency is absent* — `require-higher-order-function-1-ns` carries `<dependency type="feature" value="higherOrderFunctions" satisfied="false"/>` and is described as "An error must be thrown if the feature is not supported". Those tests ran anyway, against a runner that does support the feature, and failed.

A dependency is met when the availability of what it names matches its `satisfied` flag. That is one predicate, handles both polarities, and applies uniformly to every dependency type — #34 inverted features only while dropping the guard for `spec`/`xml-version`/`xsd-version`, which would invert those backwards. (Latent today: across QT3_1_0, `satisfied="false"` occurs only on `feature` and on four types the runner does not implement.)

Across QT3_1_0 this reclassifies 50 test cases — those naming a feature enabled by default: `higherOrderFunctions` (28), `typedData` (10), `moduleImport` (8), `collection-stability` (2), `serialization` (2). They become assumption failures rather than test failures.

## Verification

Ran the `fn-transform` test set four ways — `develop` vs. this branch, each against the `exist-core` currently in `~/.m2` and against a build carrying the forward-ported XSLT include fixes (#6544):

| runner | exist-core (Jun) | exist-core (+#6544) |
|---|---|---|
| `develop` | 16 fail, 1 skip | 14 fail, 1 skip |
| this branch | 11 fail, 4 skip | **9 fail, 4 skip** |

The runner fixes and the eXist fixes are independent and additive. On the patched eXist this branch changes exactly five cases: `fn-transform-20` and `-21` failure → pass; `fn-transform-901`, `-902`, `-err-14` failure → skipped.

Also adds the project's first unit tests. `missingDependencies` is a pure function and was untested; the new spec pins the truth table for both polarities of `satisfied`. The four inversion tests fail against `develop`'s implementation and pass against this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)