### PR TITLE
[bugfix] Add stall watchdog and forced-shutdown safety to the runner

### DIFF
--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -140,8 +140,18 @@ class ExistServer {
 
   /**
    * Shutdown the eXist-db server.
+   *
+   * A timeout thread ensures the process exits even if BrokerPool.stopAll()
+   * hangs (a known issue with thread pools that accumulate during long runs).
    */
   def stopServer(): Unit = {
+    val shutdownTimeout = new Thread(() => {
+      Thread.sleep(30000)
+      logger.warn("BrokerPool shutdown did not complete within 30 seconds, forcing exit")
+      Runtime.getRuntime.halt(0)
+    }, "exist-shutdown-timeout")
+    shutdownTimeout.setDaemon(true)
+    shutdownTimeout.start()
     existServer.stopDb()
   }
 }

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -60,6 +60,10 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
 
   private case object TimerPrintStats
 
+  private case object TimerWatchdogKey
+
+  private case object TimerWatchdogCheck
+
   private case class Stats(unparsedTestSets: Int, testCases: (Int, Int), completedTestCases: (Int, Int), unserializedTestSets: Int) {
     def asMessage: String = s"XQTSRunnerActor Progress:\nunparsedTestSets=${unparsedTestSets}\ntestCases[sets/cases]=${testCases._1}/${testCases._2}\ncompletedTestCases[sets/cases]=${completedTestCases._1}/${completedTestCases._2}\nunserializedTestSets=${unserializedTestSets}"
   }
@@ -67,16 +71,37 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
   private var previousStats: Stats = Stats(0, (0, 0), (0, 0), 0)
   private var unchangedStatsTicks = 0;
 
+  /** Number of consecutive watchdog ticks with no progress before forcing shutdown. 10s tick x 6 = 60s stall timeout. */
+  private val STALL_TIMEOUT_TICKS = 6
+  private var watchdogPreviousCompletedCount = 0
+  private var watchdogStalledTicks = 0
+  private var startedTestCases: Map[TestSetRef, Set[String]] = Map.empty
+
+  // Forced-shutdown drain state. Once `forceSerializeAndShutdown` has been
+  // called, we send any pending TestSetResults and then wait for their
+  // SerializedTestSetResults acks before triggering actor-system termination —
+  // otherwise the children get killed mid-write and the in-flight results land
+  // in deadLetters. The deadline thread is the hard backstop in case the
+  // serializer itself is wedged.
+  private var forcedShutdown = false
+  private var finalizeSent = false
+  /** Hard deadline (ms) for the forced-shutdown drain before we give up and terminate anyway. */
+  private val FORCED_DRAIN_DEADLINE_MS = 60000L
+
   override def receive: Receive = {
 
     case RunXQTS(xqtsVersion, xqtsPath, features, specs, xmlVersions, xsdVersions, maxCacheBytes, testSets, testCases, excludeTestSets, excludeTestCases) =>
       started = System.currentTimeMillis()
       logger.info(s"Running XQTS: ${XQTSVersion.label(xqtsVersion)}")
 
-      if (logger.isDebugEnabled()) {
-        // prints stats about the state of this actor (i.e. test set progress)
+      {
         import scala.concurrent.duration._
-        timers.startTimerAtFixedRate(TimerStatsKey, TimerPrintStats, 5.seconds)
+        // watchdog: detect stalls where no test cases complete for 120 seconds
+        timers.startTimerAtFixedRate(TimerWatchdogKey, TimerWatchdogCheck, 10.seconds)
+        if (logger.isDebugEnabled()) {
+          // prints stats about the state of this actor (i.e. test set progress)
+          timers.startTimerAtFixedRate(TimerStatsKey, TimerPrintStats, 5.seconds)
+        }
       }
 
       val readFileRouter = context.actorOf(FromConfig.props(Props(classOf[ReadFileActor])), name = "ReadFileRouter")
@@ -110,6 +135,31 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
       }
       previousStats = stats
 
+    case TimerWatchdogCheck =>
+      val currentCompletedCount = this.completedTestCases.values.foldLeft(0)(_ + _.size)
+      if (currentCompletedCount > watchdogPreviousCompletedCount) {
+        watchdogStalledTicks = 0
+      } else if (this.testCases.nonEmpty) {
+        // only count stall ticks after we've started receiving test cases
+        watchdogStalledTicks += 1
+      }
+      watchdogPreviousCompletedCount = currentCompletedCount
+
+      if (watchdogStalledTicks >= STALL_TIMEOUT_TICKS) {
+        val totalCases = this.testCases.values.foldLeft(0)(_ + _.size)
+        // Identify which test cases started but never completed (hung tests)
+        val hungTests = for {
+          (testSetRef, started) <- startedTestCases
+          completed = completedTestCases.getOrElse(testSetRef, Map.empty).keySet
+          testCase <- started -- completed
+        } yield s"${testSetRef.name}/$testCase"
+        logger.warn(s"Watchdog: no progress for ${STALL_TIMEOUT_TICKS * 10}s ($currentCompletedCount/$totalCases cases completed, ${unserializedTestSets.size} unserialized). Forcing shutdown.")
+        if (hungTests.nonEmpty) {
+          logger.warn(s"Hung test cases (started but never completed): ${hungTests.mkString(", ")}")
+        }
+        forceSerializeAndShutdown()
+      }
+
     case ParseComplete(xqtsVersion, _, matchedTestSets) =>
       logger.info(s"Matched $matchedTestSets Test Sets in XQTS ${XQTSVersion.toVersionName(xqtsVersion)}...")
       if (matchedTestSets == 0) {
@@ -125,7 +175,7 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
       unparsedTestSets -= testSetRef
 
       // have we completed testing an entire TestSet? NOTE: tests could have finished executing before parse complete message arrives!
-      if (isTestSetCompleted(testSetRef)) {
+      if (!unserializedTestSets.contains(testSetRef) && isTestSetCompleted(testSetRef)) {
         // serialize the TestSet results
         resultsSerializerRouter ! TestSetResults(testSetRef, completedTestCases(testSetRef).values.toSeq)
         unserializedTestSets += testSetRef
@@ -134,22 +184,37 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
     case RunningTestCase(testSetRef, testCase) =>
       logger.info(s"Starting execution of Test Case: ${testSetRef.name}/${testCase}...")
       testCases = addTestCase(testCases, testSetRef, testCase)
+      startedTestCases = addTestCase(startedTestCases, testSetRef, testCase)
 
     case RanTestCase(testSetRef, testResult) =>
       logger.info(s"Finished execution of Test Case: ${testSetRef.name}/${testResult.testCase}.")
       completedTestCases = mergeTestCases(completedTestCases, testSetRef, testResult)
 
       // have we completed testing an entire TestSet?
-      if (isTestSetCompleted(testSetRef)) {
+      if (!unserializedTestSets.contains(testSetRef) && isTestSetCompleted(testSetRef)) {
         // serialize the TestSet results
+        resultsSerializerRouter ! TestSetResults(testSetRef, completedTestCases(testSetRef).values.toSeq)
+        unserializedTestSets += testSetRef
+      } else if (!unserializedTestSets.contains(testSetRef) && isTestSetCompletedByStarted(testSetRef)) {
+        // All started test cases completed, but ParsedTestSet hasn't been processed
+        // yet (still in unparsedTestSets). This happens when BrokerPool threads block
+        // the Pekko dispatcher, preventing the ParsedTestSet message from being delivered.
+        logger.info(s"Test set ${testSetRef.name} completed (all started cases finished, ParsedTestSet pending). Serializing results.")
         resultsSerializerRouter ! TestSetResults(testSetRef, completedTestCases(testSetRef).values.toSeq)
         unserializedTestSets += testSetRef
       }
 
     case SerializedTestSetResults(testSetRef) =>
       unserializedTestSets -= testSetRef
-      if (allTestSetsCompleted()) {
-        // all TestSet results have been sent to the serializer
+      // Under a forced shutdown, hung-but-never-completed test cases mean
+      // `allTestSetsCompleted()` will never be true; relax to "all serialization
+      // acks received" so the drain can finalize. Also guard against sending
+      // FinalizeSerialization more than once.
+      val readyToFinalize =
+        !finalizeSent &&
+          (allTestSetsCompleted() || (forcedShutdown && unserializedTestSets.isEmpty))
+      if (readyToFinalize) {
+        finalizeSent = true
         resultsSerializerRouter ! FinalizeSerialization
       }
 
@@ -159,25 +224,106 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
       shutdown()
   }
 
+  private def forceSerializeAndShutdown(): Unit = {
+    // Idempotent: a second watchdog tick (or a re-entry from another path)
+    // must not start a parallel drain.
+    if (forcedShutdown) {
+      return
+    }
+    forcedShutdown = true
+
+    // Stop the watchdog now that we're committed to draining; we don't want
+    // another stall tick to log "Forcing shutdown" while serialization is
+    // already in progress.
+    timers.cancel(TimerWatchdogKey)
+
+    // Serialize any completed but unsent test sets.
+    for {
+      (testSetRef, _) <- this.testCases
+      if !unserializedTestSets.contains(testSetRef)
+      results <- completedTestCases.get(testSetRef)
+    } {
+      resultsSerializerRouter ! TestSetResults(testSetRef, results.values.toSeq)
+      unserializedTestSets += testSetRef
+    }
+
+    if (unserializedTestSets.isEmpty) {
+      // Nothing in flight — fall straight through the normal finalize/finish
+      // handshake so the serializer router gets a chance to flush its own state.
+      if (!finalizeSent) {
+        finalizeSent = true
+        resultsSerializerRouter ! FinalizeSerialization
+      }
+    } else {
+      logger.info(s"Draining ${unserializedTestSets.size} in-flight TestSetResults before shutdown (deadline ${FORCED_DRAIN_DEADLINE_MS / 1000}s)")
+    }
+
+    // Hard backstop: if the serializer never acks (e.g. wedged write), give
+    // up on the drain after FORCED_DRAIN_DEADLINE_MS and shut down anyway.
+    // The 30s deadline thread inside shutdown() is a separate backstop for
+    // actor-system termination itself.
+    val backstop = new Thread(() => {
+      try {
+        Thread.sleep(FORCED_DRAIN_DEADLINE_MS)
+        logger.warn(s"Forced-shutdown drain did not complete within ${FORCED_DRAIN_DEADLINE_MS / 1000}s; terminating anyway (${unserializedTestSets.size} TestSetResults still unacked)")
+        // Re-enter via a self-message so shutdown() runs on the actor thread.
+        self ! FinishedSerialization
+      } catch {
+        case _: InterruptedException =>
+      }
+    }, "xqts-forced-drain-backstop")
+    backstop.setDaemon(true)
+    backstop.start()
+  }
+
+  private var shutdownCalled = false
   private def shutdown(): Unit = {
+    if (shutdownCalled) {
+      return
+    }
+    shutdownCalled = true
+    timers.cancel(TimerWatchdogKey)
     if (logger.isDebugEnabled()) {
       timers.cancel(TimerStatsKey)
     }
+    // Hard deadline: force exit if actor system termination hangs.
+    // BrokerPool threads can block the Pekko dispatcher, preventing
+    // CoordinatedShutdown from completing. This standalone thread
+    // runs outside Pekko and forces JVM exit after 30 seconds.
+    logger.info("Starting 30-second shutdown deadline thread")
+    val deadline = new Thread(() => {
+      try {
+        Thread.sleep(30000)
+        logger.warn("Actor system shutdown did not complete within 30 seconds, forcing exit")
+        Runtime.getRuntime.halt(0)
+      } catch {
+        case _: InterruptedException =>
+          logger.info("Shutdown deadline thread interrupted (clean exit)")
+      }
+    }, "xqts-shutdown-deadline")
+    deadline.setDaemon(true)
+    deadline.start()
     context.stop(self)
     context.system.terminate()
   }
 
   private def isTestSetCompleted(testSetRef: TestSetRef): Boolean = {
     unparsedTestSets.contains(testSetRef) == false &&
-      completedTestCases.get(testSetRef).map(_.keySet)
-        .flatMap(completed => testCases.get(testSetRef).map(_ == completed))
-        .getOrElse(false)
+      isTestSetCompletedByStarted(testSetRef)
+  }
+
+  /** Check if all STARTED test cases have completed, ignoring ParsedTestSet status. */
+  private def isTestSetCompletedByStarted(testSetRef: TestSetRef): Boolean = {
+    completedTestCases.get(testSetRef).map(_.keySet)
+      .flatMap(completed => startedTestCases.get(testSetRef).map(started => started.nonEmpty && started == completed))
+      .getOrElse(false)
   }
 
   private def allTestSetsCompleted(): Boolean = {
-    unserializedTestSets.isEmpty &&
-      unparsedTestSets.isEmpty &&
-      !testCases.keySet.map(isTestSetCompleted(_)).contains(false)
+    unserializedTestSets.isEmpty && {
+      val testSetRefs = if (startedTestCases.nonEmpty) startedTestCases.keySet else testCases.keySet
+      testSetRefs.forall(ref => isTestSetCompleted(ref) || isTestSetCompletedByStarted(ref))
+    }
   }
 
   @unused


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Extracts the suite-agnostic runner-robustness work from the QT4 bundle (#49) into a standalone PR against `develop` for 7.0. No test semantics change — this is purely operational safety so long runs can't hang indefinitely.

## Why

On long XQTS runs the runner occasionally hangs and never terminates. Two mechanisms cause it: a single wedged test case, and BrokerPool threads that accumulate over a run and block the Pekko dispatcher — once the dispatcher is blocked, `ParsedTestSet` / `RanTestCase` messages stop flowing and the actor system never reaches a completed state. Today the only recovery is killing the process by hand (and losing the partial results).

## What changed

Two files, both additive:

- **`XQTSRunnerActor`**
  - **Stall watchdog** — a fixed-rate timer (10s tick) detects when no test cases complete for `STALL_TIMEOUT_TICKS` (60s) and triggers a graceful forced drain, logging which cases started but never completed (hung tests) to aid diagnosis.
  - **Forced-shutdown drain** — on a stall, serialize any completed-but-unsent test sets and wait for their `SerializedTestSetResults` acks (with a hard `FORCED_DRAIN_DEADLINE_MS` backstop) before terminating, so in-flight results are flushed rather than dropped into `deadLetters`.
  - **Completion-detection hardening** — track `startedTestCases` and finalize a test set once all *started* cases finish, even when its `ParsedTestSet` message is still queued behind a blocked dispatcher; guard against double-serialization and duplicate `FinalizeSerialization`.
  - **Shutdown deadline** — a standalone (non-Pekko) daemon thread `halt()`s the JVM if actor-system termination itself hangs past 30s.
- **`ExistServer.stopServer()`** — a daemon timeout thread `halt()`s the JVM if `BrokerPool.stopAll()` hangs past 30s.

## Provenance / scope

Hand-extracted from `feature/saxon-12-runner` (#49). Deliberately **excluded**: that branch's XQFTTS message-routing changes, QT4/XQ4 support, and its `application.conf` changes (which included a `sha256` regression). The diff here is exactly the robustness logic and nothing else.

## Test plan

- [x] `sbt compile` clean (warnings unchanged from develop baseline).
- [ ] Smoke test: a full or large XQTS run completes and terminates cleanly; verify the watchdog logs nothing on a healthy run and that a deliberately-stalled run drains + exits within the deadlines.

## Risk and rollback

Additive and self-contained. On a healthy run the watchdog observes progress every tick and never fires; the deadline threads are daemons that only act on a genuine hang. Reverting removes the safety nets and restores the prior (occasionally-hanging) behavior.
