### PR TITLE
[feature] Add qt4tests suite support, runnable on eXist 7 in XQ-3.1 mode

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,7 +11,9 @@ xqtsrunner {
         {
           version = HEAD
           url = "https://github.com/w3c/qt3tests/archive/master.zip"
-          sha256 = "8807ef98c79c23f25b811194e898e644ed92e6d52741636c219919b3409b2aab"
+          # HEAD tracks a moving target (qt3tests master.zip), so a pinned hash goes
+          # stale on every upstream change; skip verification (empty sha256) as for QT4.
+          sha256 = ""
           has-dir = "qt3tests-master"
           check-file = "catalog.xml"
         }
@@ -21,6 +23,13 @@ xqtsrunner {
           sha256 = "7f272de59c9fab87c1bbb8e8860855aa9b2c20261e401b2dd3d849b90c8d25e0"
           has-dir = "XQFTTS_1_0_4"
           check-file = "XQFTTSCatalog.xml"
+        }
+        {
+          version = QT4
+          url = "https://github.com/qt4cg/qt4tests/archive/master.zip"
+          sha256 = ""
+          has-dir = "qt4tests-master"
+          check-file = "catalog.xml"
         }
     ]
 

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -115,11 +115,47 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
           }
 
         case None =>
-          // error - invalid test case
-          //TODO(AR) detect this in catalog parser and inform the manager there!
-          //TODO(AR) replace these two messages with InvalidTestCase() - and let the manager deal with it
-          manager ! RunningTestCase(testSetRef, testCase.name)
-          manager ! RanTestCase(testSetRef, ErrorResult(testSetRef.name, testCase.name, -1, -1, new IllegalStateException("Invalid Test Case: No test defined for test-case")))
+          // No main test query - check if this is an update-only test case
+          if (testCase.updateTests.nonEmpty) {
+              // Update-only test with inline queries - handle like a normal inline test
+              // Check if any update test uses external files
+              val externalQueryFiles = testCase.updateTests.collect { case Right(path) => path }
+              externalQueryFiles.foreach(queryPath => {
+                commonResourceCacheActor ! GetResource(queryPath)
+                awaitingQueryStr = merge1(awaitingQueryStr)((testSetRef.name, testCase.name), queryPath)
+              })
+
+              testCase.environment match {
+                case Some(environment) if (environment.schemas.filter(_.file.nonEmpty).nonEmpty || environment.sources.nonEmpty || environment.resources.nonEmpty || environment.collections.flatMap(_.sources).nonEmpty) =>
+                  val requiredSchemas = environment.schemas.filter(_.file.nonEmpty)
+                  requiredSchemas.map(schema => commonResourceCacheActor ! GetResource(schema.file.get))
+                  awaitingSchemas = merge(awaitingSchemas)((testSetRef.name, testCase.name), requiredSchemas.map(schema => () => schema.file.get))
+
+                  environment.sources.map(source => commonResourceCacheActor ! GetResource(source.file))
+                  awaitingSources = merge(awaitingSources)((testSetRef.name, testCase.name), environment.sources.map(source => () => source.file))
+                  environment.resources.map(resource => commonResourceCacheActor ! GetResource(resource.file))
+                  awaitingResources = merge(awaitingResources)((testSetRef.name, testCase.name), environment.resources.map(resource => () => resource.file))
+                  environment.collections.map(_.sources.map(source => commonResourceCacheActor ! GetResource(source.file)))
+                  awaitingSources = merge(awaitingSources)((testSetRef.name, testCase.name), environment.collections.flatMap(_.sources).map(source => () => source.file))
+
+                  pendingTestCases = addIfNotPresent(pendingTestCases)(rtc)
+
+                case _ =>
+                  if (externalQueryFiles.nonEmpty) {
+                    // we are awaiting external query files
+                    pendingTestCases = addIfNotPresent(pendingTestCases)(rtc)
+                  } else {
+                    // we have everything we need - schedule the test case
+                    self ! RunTestCaseInternal(rtc, ResolvedEnvironment())
+                  }
+              }
+          } else {
+              // error - truly invalid test case (no test and no updateTests)
+              //TODO(AR) detect this in catalog parser and inform the manager there!
+              //TODO(AR) replace these two messages with InvalidTestCase() - and let the manager deal with it
+              manager ! RunningTestCase(testSetRef, testCase.name)
+              manager ! RanTestCase(testSetRef, ErrorResult(testSetRef.name, testCase.name, -1, -1, new IllegalStateException("Invalid Test Case: No test defined for test-case")))
+          }
       }
 
 
@@ -237,6 +273,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
     val plusFormVersion = xqtsVersion match {
       case XQTS_3_1  => "3.1"
       case XQTS_HEAD => "3.1"  // HEAD = live qt3tests master = final XQ 3.1 Rec + corrections
+      case XQTS_QT4  => "3.1"  // qt4tests runs in XQ 3.1 mode on eXist 7 (XQ40-requiring tests are
+                               // skipped via spec deps); revisit if/when an XQ4 mode enables XQ40
       case _         => "4.0"
     }
     val version =
@@ -265,6 +303,67 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    */
   @throws(classOf[OutOfMemoryError])
   private def runTestCase(connection: ExistConnection, xqtsVersion: XQTSVersion, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
+    // Set up sandpit if the environment defines one
+    val sandpitTempDir: Option[Path] = testCase.environment.flatMap(_.sandpit).map { sandpit =>
+      val tempDir = Files.createTempDirectory("xqts-sandpit-")
+      copyDirectory(sandpit.path, tempDir)
+      tempDir
+    }
+
+    try {
+      // If sandpit is active, override the static base URI to point to the temp directory
+      val effectiveTestCase = sandpitTempDir match {
+        case Some(tempDir) =>
+          val sandpitBaseUri = tempDir.toUri.toString
+          testCase.copy(environment = testCase.environment.map(_.copy(staticBaseUri = Some(sandpitBaseUri))))
+        case None => testCase
+      }
+
+      if (effectiveTestCase.updateTests.nonEmpty) {
+        runUpdateTestCase(connection, testSetName, effectiveTestCase, resolvedEnvironment)
+      } else {
+        runNonUpdateTestCase(connection, xqtsVersion, testSetName, effectiveTestCase, resolvedEnvironment)
+      }
+    } finally {
+      // Clean up sandpit temp directory
+      sandpitTempDir.foreach(deleteDirectory)
+    }
+  }
+
+  /** Recursively copy a directory tree. */
+  private def copyDirectory(source: Path, target: Path): Unit = {
+    Files.walk(source).forEach { sourcePath =>
+      val targetPath = target.resolve(source.relativize(sourcePath))
+      if (Files.isDirectory(sourcePath)) {
+        Files.createDirectories(targetPath)
+      } else {
+        Files.copy(sourcePath, targetPath)
+      }
+    }
+  }
+
+  /** Recursively delete a directory tree. */
+  private def deleteDirectory(dir: Path): Unit = {
+    try {
+      Files.walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete(_))
+    } catch {
+      case _: IOException => // best-effort cleanup
+    }
+  }
+
+  /**
+   * Run a non-update (standard) XQTS test-case.
+   *
+   * @param connection          a connection to an eXist-db server.
+   * @param testSetName         the name of the test-set of which the test-case is a part.
+   * @param testCase            the test-case to execute.
+   * @param resolvedEnvironment the environment resources for the test-case.
+   * @return the result of executing the XQTS test-case.
+   */
+  @throws(classOf[OutOfMemoryError])
+  private def runNonUpdateTestCase(connection: ExistConnection, xqtsVersion: XQTSVersion, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
     testCase.test match {
       case Some(test) =>
 
@@ -357,6 +456,199 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
       case None =>
         ErrorResult(testSetName, testCase.name, -1, -1, new IllegalStateException("No test defined for test-case"))
+    }
+  }
+
+  /**
+   * Run an XQuery Update XQTS test-case.
+   *
+   * Update tests have two phases:
+   * 1. Execute the update query (with update="true") which modifies the source document(s)
+   * 2. Execute the verification query against the modified document(s) and check the result
+   */
+  @throws(classOf[OutOfMemoryError])
+  private def runUpdateTestCase(connection: ExistConnection, testSetName: TestSetName, testCase: TestCase, resolvedEnvironment: ResolvedEnvironment): TestResult = {
+    val baseUri = testCase.environment
+      .flatMap(_.staticBaseUri.orElse(Some(testCase.file.toUri.toString)))
+      .filterNot(_ == "#UNDEFINED")
+
+    // Parse source documents once, so the same in-memory document objects are shared between update and verification queries
+    val parsedSources: Either[ExistServerException, List[(Source, org.exist.dom.memtree.DocumentImpl)]] = {
+      val initAccum: Either[ExistServerException, List[(Source, org.exist.dom.memtree.DocumentImpl)]] = Right(List.empty)
+      testCase.environment
+        .map(_.sources)
+        .getOrElse(List.empty)
+        .foldLeft(initAccum) { case (accum, source) =>
+          accum.flatMap { results =>
+            resolveSource(resolvedEnvironment, source)
+              .flatMap(rs => SAXParser.parseXml(rs.data).map(doc => {
+                doc.setDocumentURI(rs.path.toUri.toString)
+                (source, doc) +: results
+              }))
+          }
+        }
+    }
+
+    parsedSources match {
+      case Left(error) =>
+        ErrorResult(testSetName, testCase.name, error.compilationTime, error.executionTime, error)
+
+      case Right(sourceDocs) =>
+        // Build variable declarations from parsed source docs (for external variables like $input-context)
+        val externalVarDocs: List[(String, Sequence)] = sourceDocs.filter { case (source, _) =>
+          source.role.exists(_.isInstanceOf[ExternalVariableRole])
+        }.map { case (source, doc) =>
+          (source.role.get.asInstanceOf[ExternalVariableRole].name, doc.asInstanceOf[Sequence])
+        }
+
+        // Build context sequence from source with role="." (context item)
+        // For update tests, also fall back to the first mutable source as context
+        val contextDoc: Option[Sequence] = sourceDocs.find { case (source, _) =>
+          source.role.exists(Role.isContextItem)
+        }.map { case (_, doc) => doc.asInstanceOf[Sequence] }
+          .orElse(sourceDocs.find { case (source, _) => source.mutable }.map { case (_, doc) => doc.asInstanceOf[Sequence] })
+
+        // Phase 1: Execute all update queries sequentially.
+        // Each step shares the same in-memory documents, so mutations accumulate.
+        // For copy-modify-return expressions, the update query itself returns a value
+        // that may be needed for assertion checking (when no verification query exists).
+        val updateStepsResult: Either[TestResult, (Long, Long, Option[Sequence])] = {
+          var totalCompilationTime: Long = 0
+          var totalExecutionTime: Long = 0
+          var earlyResult: Option[TestResult] = None
+          var lastUpdateResult: Option[Sequence] = None
+
+          val iter = testCase.updateTests.iterator
+          while (iter.hasNext && earlyResult.isEmpty) {
+            val step = iter.next()
+            val queryString: String = step match {
+              case Left(query) => query
+              case Right(_) => resolvedEnvironment.resolvedQuery.get
+            }
+
+            connection.executeQuery(
+              queryString, false, baseUri, contextDoc,
+              Seq.empty, Seq.empty, Seq.empty,
+              testCase.environment.map(_.namespaces).getOrElse(List.empty),
+              externalVarDocs,
+              testCase.environment.map(_.decimalFormats).getOrElse(List.empty),
+              testCase.modules, false
+            ) match {
+              case Left(ex) =>
+                earlyResult = Some(ErrorResult(testSetName, testCase.name, ex.compilationTime, ex.executionTime, ex))
+
+              case Right(Result(result, ct, et)) =>
+                totalCompilationTime += ct
+                totalExecutionTime += et
+                result match {
+                  case Left(queryError) =>
+                    // An update step raised an error — check if expected
+                    earlyResult = Some(testCase.result match {
+                      case Some(Error(expected)) if expected == queryError.errorCode =>
+                        PassResult(testSetName, testCase.name, totalCompilationTime, totalExecutionTime)
+                      case Some(anyOf@AnyOf(_)) if anyOfContainsError(anyOf, queryError.errorCode) =>
+                        PassResult(testSetName, testCase.name, totalCompilationTime, totalExecutionTime)
+                      case Some(allOf@AllOf(_)) if allOfContainsError(allOf, queryError.errorCode) =>
+                        PassResult(testSetName, testCase.name, totalCompilationTime, totalExecutionTime)
+                      case Some(expectedResult) =>
+                        FailureResult(testSetName, testCase.name, totalCompilationTime, totalExecutionTime, failureMessage(expectedResult, queryError))
+                      case None =>
+                        ErrorResult(testSetName, testCase.name, totalCompilationTime, totalExecutionTime, new IllegalStateException("No defined expected result"))
+                    })
+                  case Right(queryResult) =>
+                    // Save result — needed for copy-modify-return assertions
+                    if (queryResult != null && queryResult.getItemCount > 0) {
+                      lastUpdateResult = Some(queryResult)
+                    }
+                }
+            }
+          }
+
+          earlyResult match {
+            case Some(result) => Left(result)
+            case None => Right((totalCompilationTime, totalExecutionTime, lastUpdateResult))
+          }
+        }
+
+        updateStepsResult match {
+          case Left(terminalResult) => terminalResult
+
+          case Right((updateCompTime, updateExecTime, lastUpdateResult)) =>
+            // Phase 2: Execute verification query
+            testCase.test match {
+              case Some(verifyTest) =>
+                val verifyQueryString: String = verifyTest match {
+                  case Left(query) => query
+                  case Right(_) => resolvedEnvironment.resolvedQuery.get
+                }
+
+                // For verification, use the first mutable source as context item (now modified by updates)
+                val verifyContextDoc: Option[Sequence] = sourceDocs.find { case (source, _) =>
+                  source.mutable
+                }.map { case (_, doc) => doc.asInstanceOf[Sequence] }
+                  .orElse(contextDoc)
+
+                connection.executeQuery(
+                  verifyQueryString, false, baseUri, verifyContextDoc,
+                  Seq.empty, Seq.empty, Seq.empty,
+                  testCase.environment.map(_.namespaces).getOrElse(List.empty),
+                  externalVarDocs,
+                  testCase.environment.map(_.decimalFormats).getOrElse(List.empty),
+                  testCase.modules, false
+                ) match {
+                  case Left(ex) =>
+                    ErrorResult(testSetName, testCase.name, ex.compilationTime, ex.executionTime, ex)
+
+                  case Right(Result(verifyResultValue, compilationTime, executionTime)) =>
+                    verifyResultValue match {
+                      case Left(queryError) =>
+                        testCase.result match {
+                          case Some(Error(expected)) if expected == queryError.errorCode =>
+                            PassResult(testSetName, testCase.name, compilationTime, executionTime)
+                          case Some(anyOf@AnyOf(_)) if anyOfContainsError(anyOf, queryError.errorCode) =>
+                            PassResult(testSetName, testCase.name, compilationTime, executionTime)
+                          case Some(allOf@AllOf(_)) if allOfContainsError(allOf, queryError.errorCode) =>
+                            PassResult(testSetName, testCase.name, compilationTime, executionTime)
+                          case Some(expectedResult) =>
+                            FailureResult(testSetName, testCase.name, compilationTime, executionTime, failureMessage(expectedResult, queryError))
+                          case None =>
+                            ErrorResult(testSetName, testCase.name, compilationTime, executionTime, new IllegalStateException("No defined expected result"))
+                        }
+
+                      case Right(null) =>
+                        ErrorResult(testSetName, testCase.name, compilationTime, executionTime, new IllegalStateException("eXist-db returned null from the verification query"))
+
+                      case Right(queryResult) =>
+                        testCase.result match {
+                          case Some(expectedError: Error) =>
+                            FailureResult(testSetName, testCase.name, compilationTime, executionTime, failureMessage(connection)(expectedError, queryResult))
+                          case Some(expectedResult) =>
+                            val envNamespaces = testCase.environment.map(_.namespaces).getOrElse(List.empty)
+                            processAssertion(connection, testSetName, testCase.name, compilationTime, executionTime, envNamespaces)(expectedResult, queryResult)
+                          case None =>
+                            ErrorResult(testSetName, testCase.name, compilationTime, executionTime, new IllegalStateException("No defined expected result"))
+                        }
+                    }
+                }
+
+              case None =>
+                // No verification query — update-only test or copy-modify-return
+                testCase.result match {
+                  case Some(expectedError: Error) =>
+                    // Expected an error but the update succeeded — failure
+                    FailureResult(testSetName, testCase.name, updateCompTime, updateExecTime, failureMessage(connection)(expectedError, new org.exist.xquery.value.EmptySequence()))
+                  case Some(expectedResult) if lastUpdateResult.isDefined =>
+                    // Copy-modify-return: use the update expression's return value for assertion
+                    val envNamespaces = testCase.environment.map(_.namespaces).getOrElse(List.empty)
+                    processAssertion(connection, testSetName, testCase.name, updateCompTime, updateExecTime, envNamespaces)(expectedResult, lastUpdateResult.get)
+                  case Some(_) =>
+                    // Expected a non-error result with no verification query and no update result
+                    FailureResult(testSetName, testCase.name, updateCompTime, updateExecTime, s"Expected a result but no verification query defined")
+                  case None =>
+                    PassResult(testSetName, testCase.name, updateCompTime, updateExecTime)
+                }
+            }
+        }
     }
   }
 

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -77,11 +77,13 @@ object XQTSParserActor {
   case class ExternalVariableRole(name: String) extends Role
 
 
-  case class Environment(name: String, schemas: List[Schema] = List.empty, sources: List[Source] = List.empty, resources: List[Resource] = List.empty, params: List[Param] = List.empty, contextItem: Option[String] = None, decimalFormats: List[DecimalFormat] = List.empty, namespaces: List[Namespace] = List.empty, collections: List[Collection] = List.empty, staticBaseUri: Option[String] = None, collation: Option[Collation] = None)
+  case class Sandpit(path: Path)
+
+  case class Environment(name: String, schemas: List[Schema] = List.empty, sources: List[Source] = List.empty, resources: List[Resource] = List.empty, params: List[Param] = List.empty, contextItem: Option[String] = None, decimalFormats: List[DecimalFormat] = List.empty, namespaces: List[Namespace] = List.empty, collections: List[Collection] = List.empty, staticBaseUri: Option[String] = None, collation: Option[Collation] = None, sandpit: Option[Sandpit] = None)
 
   case class Schema(uri: Option[AnyURIValue], file: Option[Path], xsdVersion: Float = 1.0f, description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
 
-  case class Source(role: Option[Role], file: Path, uri: Option[String], validation: Option[Validation.Validation] = None, description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
+  case class Source(role: Option[Role], file: Path, uri: Option[String], validation: Option[Validation.Validation] = None, mutable: Boolean = false, declared: Boolean = false, description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
 
   case class Resource(file: Path, uri: String, mediaType: Option[String] = None, encoding: Option[String], description: Option[String] = None, created: Option[Created] = None, modifications: List[Modified] = List.empty)
 
@@ -113,7 +115,7 @@ object XQTSParserActor {
 
   case class Dependency(`type`: DependencyType, value: String, satisfied: Boolean)
 
-  case class TestCase(file: Path, name: TestCaseName, covers: String, description: Option[String] = None, created: Option[Created] = None, modifications: Seq[Modified] = Seq.empty, environment: Option[Environment] = None, modules: Seq[Module] = Seq.empty, dependencies: Seq[Dependency] = Seq.empty, test: Option[Either[String, Path]] = None, result: Option[Result] = None)
+  case class TestCase(file: Path, name: TestCaseName, covers: String, description: Option[String] = None, created: Option[Created] = None, modifications: Seq[Modified] = Seq.empty, environment: Option[Environment] = None, modules: Seq[Module] = Seq.empty, dependencies: Seq[Dependency] = Seq.empty, test: Option[Either[String, Path]] = None, updateTests: Seq[Either[String, Path]] = Seq.empty, result: Option[Result] = None)
 
   sealed trait Result
 
@@ -208,6 +210,8 @@ object XQTSParserActor {
     val UnicodeNormalizationForm = DependencyTypeVal("unicode-normalization-form")
     val XmlVersion = DependencyTypeVal("xml-version")
     val XsdVersion = DependencyTypeVal("xsd-version")
+    val Revalidation = DependencyTypeVal("revalidation")
+    val Put = DependencyTypeVal("put")
   }
 
   /**
@@ -215,7 +219,7 @@ object XQTSParserActor {
    */
   object Spec extends Enumeration {
     type Spec = Value
-    val XP10, XP20, XP30, XP31, XQ10, XQ30, XQ31, XT30 = Value
+    val XP10, XP20, XP30, XP31, XP40, XQ10, XQ30, XQ31, XQ40, XT30 = Value
 
     /**
      * Returns all specs which implement at
@@ -227,20 +231,24 @@ object XQTSParserActor {
     def atLeast(spec: Spec): Set[Spec] = {
       spec match {
         case XP10 =>
-          Set(XP10, XP20, XP30, XP31)
+          Set(XP10, XP20, XP30, XP31, XP40)
         case XP20 =>
-          Set(XP20, XP30, XP31)
+          Set(XP20, XP30, XP31, XP40)
         case XP30 =>
-          Set(XP30, XP31)
+          Set(XP30, XP31, XP40)
         case XP31 =>
-          Set(XP31)
+          Set(XP31, XP40)
+        case XP40 =>
+          Set(XP40)
 
         case XQ10 =>
-          Set(XQ10, XQ30, XQ31)
+          Set(XQ10, XQ30, XQ31, XQ40)
         case XQ30 =>
-          Set(XQ30, XQ31)
+          Set(XQ30, XQ31, XQ40)
         case XQ31 =>
-          Set(XQ31)
+          Set(XQ31, XQ40)
+        case XQ40 =>
+          Set(XQ40)
 
         case XT30 =>
           Set(XT30)
@@ -285,6 +293,7 @@ object XQTSParserActor {
     val XPath_1_0_Compatibility = FeatureVal("xpath-1.0-compatibility")
     val TransformXSLT = FeatureVal("fn-transform-XSLT")
     val TransformXSLT_30 = FeatureVal("fn-transform-XSLT30")
+    val XQUpdate = FeatureVal("XQUpdate")
   }
 
   /**

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -91,7 +91,8 @@ object XQTSRunner {
     TypedData,
     XPath_1_0_Compatibility,
     TransformXSLT,
-    TransformXSLT_30
+    TransformXSLT_30,
+    XQUpdate
   )
 
   /**
@@ -154,7 +155,7 @@ object XQTSRunner {
 
       opt[XQTSVersion]('x', "xqts-version")
         .text("The version of XQTS to run. These are configured in the application.conf file. We ship with 'W3C' (the final W3C XQTS 3.1) and 'HEAD' (the GitHub community maintained XQTS) pre-configured")
-        .validate(x => if (x == XQTS_3_1 || x == XQTS_HEAD || x == XQTS_FTTS_1_0) success else failure("only version 3.1, HEAD, or FTTS is currently supported"))
+        .validate(x => if (x == XQTS_3_1 || x == XQTS_HEAD || x == XQTS_QT4 || x == XQTS_FTTS_1_0) success else failure("only version 3.1, HEAD, QT4, or FTTS is currently supported"))
         .action((x, c) => c.copy(xqtsVersion = x))
 
       opt[Path]('l', "local-dir")
@@ -361,11 +362,11 @@ private class XQTSRunner {
   @throws[IllegalArgumentException]
   private def getParserActorClass(xqtsVersion: XQTSVersion): Class[_ <: XQTSParserActor] = {
     xqtsVersion match {
-      case XQTS_3_1 | XQTS_HEAD =>
+      case XQTS_3_1 | XQTS_HEAD | XQTS_QT4 =>
         classOf[XQTS3CatalogParserActor]
       case XQTS_FTTS_1_0 =>
         classOf[xqftts.XQFTTSCatalogParserActor]
-      case _ => throw new IllegalArgumentException(s"We only support XQTS version 3.1, HEAD, or FTTS, but version: ${XQTSVersion.label(xqtsVersion)} was requested")
+      case _ => throw new IllegalArgumentException(s"We only support XQTS version 3.1, HEAD, QT4, or FTTS, but version: ${XQTSVersion.label(xqtsVersion)} was requested")
     }
   }
 
@@ -401,14 +402,19 @@ private class XQTSRunner {
     def hasLocalCopy(xqtsLocalPath: Path, xqtsCheckFile: String) = Files.exists(xqtsLocalPath) && Files.exists(xqtsLocalPath.resolve(xqtsCheckFile))
 
     def verifySha256(path: Path, sha256: String): Either[Throwable, Path] = {
-      Checksum.checksum(path, SHA256).map(_.map(_.toChar).mkString) match {
-        case Right(pathSha256) =>
-          if (sha256.equals(sha256)) {
-            Right(path)
-          } else {
-            Left(new IOException(s"Downloaded file checksum is: $pathSha256 but expected $sha256"))
-          }
-        case Left(e) => Left(e)
+      if (sha256.isEmpty) {
+        logger.info(s"No expected sha256 configured for $path; skipping checksum verification")
+        Right(path)
+      } else {
+        Checksum.checksum(path, SHA256).map(_.map(_.toChar).mkString) match {
+          case Right(pathSha256) =>
+            if (sha256.equals(pathSha256)) {
+              Right(path)
+            } else {
+              Left(new IOException(s"Downloaded file checksum is: $pathSha256 but expected $sha256"))
+            }
+          case Left(e) => Left(e)
+        }
       }
     }
 

--- a/src/main/scala/org/exist/xqts/runner/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/package.scala
@@ -36,6 +36,7 @@ package object runner {
   object XQTS_HEAD extends XQTSVersion
 
   object XQTS_FTTS_1_0 extends XQTSVersion
+  object XQTS_QT4 extends XQTSVersion
 
   object XQTSVersion {
 
@@ -53,6 +54,7 @@ package object runner {
         case "3.1" | "31" => XQTS_3_1
         case "head" | "HEAD" => XQTS_HEAD
         case "ftts" | "FTTS" | "XQFTTS" | "xqftts" => XQTS_FTTS_1_0
+        case "qt4" | "QT4" => XQTS_QT4
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $s")
       }
     }
@@ -71,6 +73,7 @@ package object runner {
         case 31 => XQTS_3_1
         case -1 => XQTS_HEAD
         case -3 => XQTS_FTTS_1_0
+        case -2 => XQTS_QT4
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $i")
       }
     }
@@ -89,6 +92,7 @@ package object runner {
         case 3.1f => XQTS_3_1
         case -1 => XQTS_HEAD
         case -3 => XQTS_FTTS_1_0
+        case -2 => XQTS_QT4
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $f")
       }
     }
@@ -111,6 +115,8 @@ package object runner {
           "XQTS_HEAD"
         case XQTS_FTTS_1_0 =>
           "XQTS_FTTS_1_0"
+        case XQTS_QT4 =>
+          "XQTS_QT4"
       }
     }
 
@@ -132,6 +138,8 @@ package object runner {
           "HEAD"
         case XQTS_FTTS_1_0 =>
           "FTTS"
+        case XQTS_QT4 =>
+          "QT4"
       }
     }
   }

--- a/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/XQTS3TestSetParserActor.scala
@@ -82,6 +82,7 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
 
   private var currentNormalizeSpace: Option[Boolean] = None
   private var currentFile: Option[Path] = None
+  private var currentTestIsUpdate: Boolean = false
   private var currentFlags: Option[String] = None
   private var currentIgnorePrefixes: Option[Boolean] = None
 
@@ -289,7 +290,9 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           val file = asyncReader.getAttributeValue(ATTR_FILE)
           val validation = asyncReader.getAttributeValueOptNE(ATTR_VALIDATION)
           val uri = asyncReader.getAttributeValueOptNE(ATTR_URI)
-          currentSource = Some(Source(role, testSetDir.resolve(file), uri, validation.map(Validation.withName)))
+          val mutable = asyncReader.getAttributeValueOptNE("mutable").exists(_.equalsIgnoreCase("true"))
+          val declared = asyncReader.getAttributeValueOptNE("declared").exists(_.equalsIgnoreCase("true"))
+          currentSource = Some(Source(role, testSetDir.resolve(file), uri, validation.map(Validation.withName), mutable, declared))
 
         case END_ELEMENT if (asyncReader.getLocalName == ELEM_SOURCE && currentEnv.nonEmpty && currentCollection.nonEmpty) =>
           currentCollection = currentSource.map(source => currentCollection.map(collection => collection.copy(sources = source +: collection.sources)))
@@ -359,6 +362,11 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
           val uri = asyncReader.getAttributeValueOptNE(ATTR_URI)
           currentEnv = currentEnv.map(_.copy(staticBaseUri = uri))
 
+        case START_ELEMENT if (asyncReader.getLocalName == ELEM_SANDPIT && currentEnv.nonEmpty) =>
+          val path = asyncReader.getAttributeValue(ATTR_PATH)
+          val resolvedPath = testSetDir.resolve(path)
+          currentEnv = currentEnv.map(_.copy(sandpit = Some(Sandpit(resolvedPath))))
+
         case START_ELEMENT if (asyncReader.getLocalName == ELEM_COLLATION && currentEnv.nonEmpty) =>
           val uri = asyncReader.getAttributeValueOptNE(ATTR_URI).map(new URI(_))
           val default = asyncReader.getAttributeValueOptNE(ATTR_DEFAULT).map(_.toBoolean).getOrElse(false)
@@ -401,13 +409,20 @@ class XQTS3TestSetParserActor(xmlParserBufferSize: Int, testCaseRunnerActor: Act
         case START_ELEMENT if (currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_TEST) =>
           val attrFile = asyncReader.getAttributeValueOpt(ATTR_FILE)
           currentFile = attrFile.map(file => testSetRef.file.resolveSibling(file))
+          currentTestIsUpdate = asyncReader.getAttributeValueOptNE("update").exists(_.equalsIgnoreCase("true"))
           captureText = true
 
         case END_ELEMENT if (currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_TEST) =>
-          currentTestCase = currentTestCase.map(testCase => testCase.copy(test = currentText.flatMap(text => Some(Left(text))).orElse(currentFile.map(Right(_)))))
+          val testValue = currentText.flatMap(text => Some(Left(text))).orElse(currentFile.map(Right(_)))
+          if (currentTestIsUpdate) {
+            currentTestCase = currentTestCase.map(testCase => testCase.copy(updateTests = testCase.updateTests ++ testValue.toSeq))
+          } else {
+            currentTestCase = currentTestCase.map(testCase => testCase.copy(test = testValue))
+          }
           currentFile = None
           currentText = None
           captureText = false
+          currentTestIsUpdate = false
 
         case START_ELEMENT if (currentTestCase.nonEmpty && asyncReader.getLocalName == ELEM_RESULT) =>
           currentResult = Some(Stack.empty)

--- a/src/main/scala/org/exist/xqts/runner/qt3/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/qt3/package.scala
@@ -44,6 +44,7 @@ package object qt3 {
   val ELEM_COLLECTION = "collection"
   val ELEM_STATIC_BASE_URI = "static-base-uri"
   val ELEM_COLLATION = "collation"
+  val ELEM_SANDPIT = "sandpit"
   val ELEM_TEST_SET = "test-set"
   val ELEM_LINK = "link"
   val ELEM_TEST_CASE = "test-case"
@@ -106,6 +107,7 @@ package object qt3 {
   val ATTR_INFINITY = "infinity"
   val ATTR_NAN = "NaN"
   val ATTR_DEFAULT = "default"
+  val ATTR_PATH = "path"
 
   private[qt3] val PARSER_FACTORY = new InputFactoryImpl
 


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Adds the [qt4cg/qt4tests](https://github.com/qt4cg/qt4tests) suite (`--xqts-version QT4`) and makes it **runnable against an eXist that supports only XQuery 3.1**: tests requiring XQuery 4.0 are automatically skipped, and everything else runs under eXist's default 3.1 semantics. Extracted from the QT4 bundle (#49) as the suite-agnostic, 7.0-eligible slice — it deliberately does **not** bring the XQ4 `xquery version "4.0"` auto-prepend, XQFTTS, the EXPath modules, or the batch runner.

## Why

Most of qt4tests is not XQ4-specific. Across the suite the spec dependencies split roughly half `XQ10+` / `XQ30+` / `XQ31+` (runnable under 3.1) and half `XQ40+` (needs XQ4) — and notably the update-facility tests in `upd/` are `XQ30+` + `XQUpdate`, i.e. XQuery *Update Facility* tests that run under 3.1, not XQ4-language tests. So the bulk of qt4tests can provide real test coverage on eXist 7 today, provided XQ4-requiring tests are excluded rather than run-and-failed.

## How the 3.1 mode works

No new "mode" flag — it falls out of the existing spec-dependency filtering:

- QT4 keeps the pre-XQ4 `DEFAULT_SPECS` (XQ40 is **not** enabled by default). A test whose `spec` dependency is `XQ40+` / `XP40+` is therefore unsatisfiable and recorded as an **assumption failure** rather than run-and-fail; `XQ10+` / `XQ30+` / `XQ31+` and strict pre-XQ4 tests stay satisfied and run.
- No `xquery version "4.0"` is prepended, so surviving tests parse under eXist's default (3.1).
- Enabling XQ4 later (once the engine supports it) is a **config change** (`--enable-specs XQ40`), not a code change.

## What changed

- New `XQTS_QT4` version (`--xqts-version QT4`) + download config (moving-target `master.zip`; empty `sha256` skips verification), and parser dispatch reusing the existing `XQTS3CatalogParserActor` — qt4tests uses the same catalog format.
- `Spec` gains `XP40` / `XQ40` and the `revalidation` / `put` dependency types, so qt4tests catalogs parse (these values occur in the catalog even for skipped tests).
- XQuery Update (XQUF) execution, gated purely on test metadata (`testCase.updateTests.nonEmpty`): parse and run multi-step update test cases, using the mutated source document as the verification context.
- Sandpit support: a per-test writable temp directory for tests declaring `<environment><sandpit path="…"/>`, with the static base URI pointed at the temp copy and cleanup afterward.
- Incidental fix: `verifySha256` compared `sha256.equals(sha256)` (always true — checksum verification was a silent no-op); corrected to compare against the downloaded file's actual hash while adding the empty-sha256 skip. Happy to split this out if you'd rather keep the diff minimal.

## Validation (against current develop `exist-core`)

Ran several qt4tests test sets with `--xqts-version QT4`:

| Test set | tests | pass | skipped (XQ4) | fail | notes |
|---|---|---|---|---|---|
| `fn-element-to-map` | 143 | 0 | **143** | 0 | XQ4-heavy — every test skipped: *"dependencies not satisfiable. Missing: [spec=XP40+ XQ40+]"* |
| `fn-abs` | 189 | **189** | 0 | 0 | pure XQ3.x — all pass on eXist 7 |
| `op-numeric-add` | 155 | 139 | 15 | 1 | XQ4 tests skip, rest run |
| `upd-DeleteExpressions` | 30 | 0 | 0 | 30 | update tests **execute** but fail — see below |

The XQ4 tests skip cleanly (assumption failures, not spurious failures), and XQ3.x tests genuinely pass.

## Dependency: XQUF update tests need eXist-db/exist#6214

The `upd/` update tests currently fail with `XPST0003 unexpected token: node` — eXist's parser doesn't yet accept `insert node` / `delete node` because the current `exist-core` lacks the XQuery Update Facility. That's **eXist-db/exist#6214** ("Implement W3C XQuery Update Facility 3.0"), which is open with 2 approvals. The runner side is correct — it executes the update tests (they're `XQ30+` + `XQUpdate`, satisfiable) and records eXist's parse errors; they should pass once #6214 lands and a new `exist-core` snapshot publishes.

## Relationship to other PRs

- Complements **#55** (`applyVersionHint`): this PR relies on eXist's default 3.1 for surviving tests, so it does not depend on #55; once #55 lands, its per-spec version-hint (with the floor keyed on enabled specs) refines version handling for both 3.1 and QT4.
- Relies on the spec-dependency filtering hardened in **#62** for the clean XQ4-skip behavior; ideally lands after #62.

## Test plan

- [x] `sbt compile` clean (warnings unchanged from develop baseline).
- [x] qt4tests runs end-to-end in QT4 mode; XQ4 tests skip, XQ3.x tests pass (data above).
- [ ] Re-run the `upd/` sets once eXist-db/exist#6214 lands to confirm the update tests pass.

## Risk and rollback

Additive: a new suite plus metadata-gated update/sandpit paths; no change to the 3.1/HEAD suites' behavior. Reverting removes the QT4 suite and the update/sandpit execution.
