### PR TITLE
[feature] Add XQFTTS 1.0.4 (W3C XPath/XQuery Full-Text Test Suite) support

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,6 +15,13 @@ xqtsrunner {
           has-dir = "qt3tests-master"
           check-file = "catalog.xml"
         }
+        {
+          version = FTTS
+          url = "https://dev.w3.org/2007/xpath-full-text-10-test-suite/XQFTTS_1_0_4.zip"
+          sha256 = "7f272de59c9fab87c1bbb8e8860855aa9b2c20261e401b2dd3d849b90c8d25e0"
+          has-dir = "XQFTTS_1_0_4"
+          check-file = "XQFTTSCatalog.xml"
+        }
     ]
 
     local-dir = "work"

--- a/src/main/scala/org/exist/xqts/runner/ExistServer.scala
+++ b/src/main/scala/org/exist/xqts/runner/ExistServer.scala
@@ -111,6 +111,12 @@ class ExistServer {
   private val logger = Logger(classOf[ExistServer])
 
   /**
+    * Global context attributes to set on every XQuery execution context.
+    * Used by the XQFTTS catalog parser to provide stop word and thesaurus URI mappings.
+    */
+  @volatile var globalContextAttributes: Map[String, AnyRef] = Map.empty
+
+  /**
    * Starts the eXist-db server.
    *
    * @return Success or Failure.
@@ -135,7 +141,7 @@ class ExistServer {
       //          .flatTap(_ => IOUtil.printlnExecutionContext("Broker/Release"))  // enable for debugging
     }
 
-    ExistConnection(brokerRes)
+    ExistConnection(brokerRes, () => globalContextAttributes)
   }
 
   /**
@@ -157,7 +163,8 @@ class ExistServer {
 }
 
 private object ExistConnection {
-  def apply(brokerRes: Resource[IO, DBBroker]) = new ExistConnection(brokerRes)
+  def apply(brokerRes: Resource[IO, DBBroker], contextAttributesSupplier: () => Map[String, AnyRef] = () => Map.empty) =
+    new ExistConnection(brokerRes, contextAttributesSupplier)
 }
 
 /**
@@ -165,8 +172,9 @@ private object ExistConnection {
  * to an eXist-db server, i.e. a [[DBBroker]]
  *
  * @param brokerRes the eXist-db broker to wrap.
+ * @param contextAttributesSupplier supplies context attributes to set on each XQuery execution context.
  */
-class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
+class ExistConnection(brokerRes: Resource[IO, DBBroker], contextAttributesSupplier: () => Map[String, AnyRef] = () => Map.empty) {
 
   /**
    * Execute an XQuery with eXist-db.
@@ -495,7 +503,14 @@ class ExistConnection(brokerRes: Resource[IO, DBBroker]) {
     }
 
     val source = new StringSource(query)
-    val fnConfigureContext: XQueryContext => XQueryContext = setupContext(_)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, decimalFormats, modules, xpath1Compatibility)
+    val fnConfigureContext: XQueryContext => XQueryContext = { ctx =>
+      val configured = setupContext(ctx)(staticBaseUri, availableDocuments, availableCollections, availableTextResources, namespaces, externalVariables, decimalFormats, modules, xpath1Compatibility)
+      // Set global context attributes (e.g., ft.stopWordURIMap, ft.thesaurusURIMap from XQFTTS catalog)
+      for ((key, value) <- contextAttributesSupplier()) {
+        configured.setAttribute(key, value.asInstanceOf[Object])
+      }
+      configured
+    }
 
     val res: IO[Either[ExistServerException, Result]] =
       SingleThreadedExecutorPool.newResource().use { singleThreadedExecutor =>

--- a/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/TestCaseRunnerActor.scala
@@ -655,8 +655,8 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
       case AssertType(expectedType) =>
         assertType(testSetName, testCaseName, compilationTime, executionTime)(expectedType, actualResult)
 
-      case AssertXml(expectedXml, ignorePrefixes) =>
-        assertXml(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expectedXml, ignorePrefixes, actualResult)
+      case AssertXml(expectedXml, ignorePrefixes, normalizeWhitespace) =>
+        assertXml(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expectedXml, ignorePrefixes, normalizeWhitespace, actualResult)
 
       case SerializationMatches(expected, flags) =>
         serializationMatches(connection, testSetName, testCaseName, compilationTime, executionTime, assertionNamespaces)(expected, flags, actualResult)
@@ -669,6 +669,10 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
       case AssertTrue =>
         assertTrue(testSetName, testCaseName, compilationTime, executionTime)(actualResult)
+
+      case AssertInspect =>
+        // "Inspect" comparison: cannot automatically verify, always passes
+        PassResult(testSetName, testCaseName, compilationTime, executionTime)
 
       case Error(expected) =>
         FailureResult(testSetName, testCaseName, compilationTime, executionTime, s"error: expected='$expected', but no error was raised")
@@ -1267,7 +1271,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual          the actual result from executing the XQuery.
    * @return the test result from processing the assertion.
    */
-  private def assertXml(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expectedXml: Either[String, Path], @unused ignorePrefixes: Boolean, actual: ExistServer.QueryResult): TestResult = {
+  private def assertXml(connection: ExistConnection, testSetName: TestSetName, testCaseName: TestCaseName, compilationTime: CompilationTime, executionTime: ExecutionTime, assertionNamespaces: Seq[Namespace] = Seq.empty)(expectedXml: Either[String, Path], @unused ignorePrefixes: Boolean, normalizeWhitespace: Boolean, actual: ExistServer.QueryResult): TestResult = {
     expectedXml.map(readTextFile(_)).fold(Right(_), r => r) match {
       case Left(t) =>
         ErrorResult(testSetName, testCaseName, compilationTime, executionTime, t)
@@ -1336,7 +1340,7 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
 
                           case current@Right(results) =>
                             val strExpectedResult = expectedQueryResult.itemAt(itemIdx).asInstanceOf[StringValue].getStringValue
-                            val differences = findDifferences(strExpectedResult, strActualResult)
+                            val differences = findDifferences(strExpectedResult, strActualResult, normalizeWhitespace)
                             differences match {
                               // if we have an error don't process anything else, just perpetuate the error
                               case Left(diffError) =>
@@ -1425,12 +1429,15 @@ class TestCaseRunnerActor(existServer: ExistServer, commonResourceCacheActor: Ac
    * @param actual   the actual XML document.
    * @return Some string describing the differences, or None of there are no differences.
    */
-  private def findDifferences(expected: String, actual: String): Either[XMLUnitException, Option[String]] = {
+  private def findDifferences(expected: String, actual: String, normalizeWs: Boolean = false): Either[XMLUnitException, Option[String]] = {
     try {
       val expectedSource = Input.fromString(s"<$IGNORABLE_WRAPPER_ELEM_NAME>$expected</$IGNORABLE_WRAPPER_ELEM_NAME>").build()
       val actualSource = Input.fromString(s"<$IGNORABLE_WRAPPER_ELEM_NAME>$actual</$IGNORABLE_WRAPPER_ELEM_NAME>").build()
-      val diff = DiffBuilder.compare(expectedSource)
+      val builder = DiffBuilder.compare(expectedSource)
         .withTest(actualSource)
+      // XQFTTS Fragment comparisons additionally collapse insignificant whitespace.
+      val builderWithWs = if (normalizeWs) builder.normalizeWhitespace() else builder
+      val diff = builderWithWs
         .withNodeFilter(new org.xmlunit.util.Predicate[org.w3c.dom.Node] {
           override def test(node: org.w3c.dom.Node): Boolean =
             !(node.getNodeType == org.w3c.dom.Node.TEXT_NODE && node.getTextContent.trim.isEmpty)

--- a/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSParserActor.scala
@@ -158,7 +158,7 @@ object XQTSParserActor {
 
   case class AssertType(expected: String) extends ValueAssertion[String]
 
-  case class AssertXml(expected: Either[String, Path], ignorePrefixes: Boolean = false) extends ValueAssertion[Either[String, Path]]
+  case class AssertXml(expected: Either[String, Path], ignorePrefixes: Boolean = false, normalizeWhitespace: Boolean = false) extends ValueAssertion[Either[String, Path]]
 
   case class SerializationMatches(expected: Either[String, Path], flags: Option[String] = None) extends ValueAssertion[Either[String, Path]]
 
@@ -167,6 +167,9 @@ object XQTSParserActor {
   case object AssertTrue extends Assertion
 
   case object AssertFalse extends Assertion
+
+  /** Assertion for "Inspect" comparisons that always passes (requires manual review). */
+  case object AssertInspect extends Assertion
 
   case class Error(expected: String) extends ValueAssertion[String]
 

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunner.scala
@@ -154,7 +154,7 @@ object XQTSRunner {
 
       opt[XQTSVersion]('x', "xqts-version")
         .text("The version of XQTS to run. These are configured in the application.conf file. We ship with 'W3C' (the final W3C XQTS 3.1) and 'HEAD' (the GitHub community maintained XQTS) pre-configured")
-        .validate(x => if (x == XQTS_3_1 || x == XQTS_HEAD) success else failure("only version 3.1, or HEAD is currently supported"))
+        .validate(x => if (x == XQTS_3_1 || x == XQTS_HEAD || x == XQTS_FTTS_1_0) success else failure("only version 3.1, HEAD, or FTTS is currently supported"))
         .action((x, c) => c.copy(xqtsVersion = x))
 
       opt[Path]('l', "local-dir")
@@ -363,7 +363,9 @@ private class XQTSRunner {
     xqtsVersion match {
       case XQTS_3_1 | XQTS_HEAD =>
         classOf[XQTS3CatalogParserActor]
-      case _ => throw new IllegalArgumentException(s"We only support XQTS version 3.1 or HEAD, but version: ${XQTSVersion.label(xqtsVersion)} was requested")
+      case XQTS_FTTS_1_0 =>
+        classOf[xqftts.XQFTTSCatalogParserActor]
+      case _ => throw new IllegalArgumentException(s"We only support XQTS version 3.1, HEAD, or FTTS, but version: ${XQTSVersion.label(xqtsVersion)} was requested")
     }
   }
 

--- a/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/XQTSRunnerActor.scala
@@ -109,8 +109,14 @@ class XQTSRunnerActor(xmlParserBufferSize: Int, existServer: ExistServer, parser
 
       val testCaseRunnerRouter = context.actorOf(FromConfig.props(Props(classOf[TestCaseRunnerActor], existServer, commonResourceCacheActor)), name = "TestCaseRunnerRouter")
 
-      val testSetParserRouter = context.actorOf(FromConfig.props(Props(classOf[XQTS3TestSetParserActor], xmlParserBufferSize, testCaseRunnerRouter)), "XQTS3TestSetParserRouter")
-      val parserActor = context.actorOf(Props(parserActorClass, xmlParserBufferSize, testSetParserRouter), parserActorClass.getSimpleName)
+      // For XQFTTS, the catalog parser sends directly to the test case runner (no test-set parser needed).
+      // For QT3, the catalog parser sends to a test-set parser pool which then sends to test case runners.
+      val parserActor = if (xqtsVersion == XQTS_FTTS_1_0) {
+        context.actorOf(Props(parserActorClass, xmlParserBufferSize, testCaseRunnerRouter, existServer), parserActorClass.getSimpleName)
+      } else {
+        val testSetParserRouter = context.actorOf(FromConfig.props(Props(classOf[XQTS3TestSetParserActor], xmlParserBufferSize, testCaseRunnerRouter)), "XQTS3TestSetParserRouter")
+        context.actorOf(Props(parserActorClass, xmlParserBufferSize, testSetParserRouter), parserActorClass.getSimpleName)
+      }
 
       parserActor ! Parse(xqtsVersion, xqtsPath, features, specs, xmlVersions, xsdVersions, testSets, testCases, excludeTestSets, excludeTestCases)
 

--- a/src/main/scala/org/exist/xqts/runner/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/package.scala
@@ -35,6 +35,8 @@ package object runner {
 
   object XQTS_HEAD extends XQTSVersion
 
+  object XQTS_FTTS_1_0 extends XQTSVersion
+
   object XQTSVersion {
 
     /**
@@ -50,6 +52,7 @@ package object runner {
         case "3.0" | "3" => XQTS_3_0
         case "3.1" | "31" => XQTS_3_1
         case "head" | "HEAD" => XQTS_HEAD
+        case "ftts" | "FTTS" | "XQFTTS" | "xqftts" => XQTS_FTTS_1_0
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $s")
       }
     }
@@ -67,6 +70,7 @@ package object runner {
         case 3 => XQTS_3_0
         case 31 => XQTS_3_1
         case -1 => XQTS_HEAD
+        case -3 => XQTS_FTTS_1_0
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $i")
       }
     }
@@ -84,6 +88,7 @@ package object runner {
         case 3 | 3.0f => XQTS_3_0
         case 3.1f => XQTS_3_1
         case -1 => XQTS_HEAD
+        case -3 => XQTS_FTTS_1_0
         case _ => throw new IllegalArgumentException(s"No such XQTS version: $f")
       }
     }
@@ -104,6 +109,8 @@ package object runner {
           "XQTS_3_1"
         case XQTS_HEAD =>
           "XQTS_HEAD"
+        case XQTS_FTTS_1_0 =>
+          "XQTS_FTTS_1_0"
       }
     }
 
@@ -123,6 +130,8 @@ package object runner {
           "3.1"
         case XQTS_HEAD =>
           "HEAD"
+        case XQTS_FTTS_1_0 =>
+          "FTTS"
       }
     }
   }

--- a/src/main/scala/org/exist/xqts/runner/xqftts/XQFTTSCatalogParserActor.scala
+++ b/src/main/scala/org/exist/xqts/runner/xqftts/XQFTTSCatalogParserActor.scala
@@ -1,0 +1,441 @@
+/*
+ * Copyright (C) 2018  The eXist Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exist.xqts.runner.xqftts
+
+import java.nio.ByteBuffer
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.{Files, Path}
+import java.util.regex.Pattern
+import org.apache.pekko.actor.ActorRef
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE
+import com.fasterxml.aalto.{AsyncByteBufferFeeder, AsyncXMLStreamReader}
+
+import javax.xml.stream.XMLStreamConstants.{CHARACTERS, END_DOCUMENT, END_ELEMENT, START_ELEMENT}
+import org.exist.xqts.runner._
+import org.exist.xqts.runner.XQTSParserActor._
+import org.exist.xqts.runner.TestCaseRunnerActor.RunTestCase
+import org.exist.xqts.runner.XQTSRunnerActor.{ParsedTestSet, ParsingTestSet, RunningTestCase}
+import org.exist.xqts.runner.xqftts._
+
+import scala.annotation.tailrec
+
+/**
+  * Parses an XQFTTS 1.0.4 XQFTTSCatalog.xml file.
+  *
+  * Unlike the QT3 parsers which split catalog and test-set parsing,
+  * this actor handles both since XQFTTS puts everything in one file.
+  * For each test-case parsed, an execution request will be sent
+  * to a TestCaseRunnerActor.
+  *
+  * @param xmlParserBufferSize the maximum buffer size for XML parsing.
+  * @param testCaseRunnerRouter a router to test case runner actors.
+  */
+class XQFTTSCatalogParserActor(xmlParserBufferSize: Int, testCaseRunnerRouter: ActorRef, existServer: ExistServer) extends XQTSParserActor {
+
+  private val logger = Logger(classOf[XQFTTSCatalogParserActor])
+
+  // Source lookup: ID -> resolved file path
+  private var sources: Map[String, Path] = Map.empty
+
+  // Stop word URI -> local file path mapping (populated from <stopwords> catalog elements)
+  private var stopWordURIMap: Map[String, Path] = Map.empty
+
+  // Thesaurus URI -> local file path mapping (populated from <thesaurus> catalog elements)
+  private var thesaurusURIMap: Map[String, Path] = Map.empty
+
+  // Test group tracking
+  private var groupStack: List[String] = List.empty
+  private var currentFilePath: List[Option[String]] = List.empty // parallel stack for FilePath
+
+  // Current test-case state
+  private var currentTestCaseName: Option[String] = None
+  private var currentTestCaseFilePath: Option[String] = None
+  private var currentTestCaseScenario: Option[String] = None
+  private var currentQueryName: Option[String] = None
+  private var currentInputFiles: List[(String, String)] = List.empty // (variable, sourceID)
+  private var currentContextItem: Option[String] = None // sourceID for context item
+  private var currentOutputFiles: List[(String, Path)] = List.empty // (compareType, resolvedPath)
+  private var currentExpectedErrors: List[String] = List.empty
+
+  // Temporary state for text capture within input-file / output-file / expected-error
+  private var captureText = false
+  private var currentText: Option[String] = None
+  private var currentInputVariable: Option[String] = None
+  private var currentCompareType: Option[String] = None
+
+  // Offset paths from the catalog root element
+  private var queryOffsetPath: String = XQUERY_QUERY_OFFSET
+  private var resultOffsetPath: String = RESULT_OFFSET
+  private var sourceOffsetPath: String = "./"
+  private var queryFileExtension: String = XQUERY_FILE_EXT
+
+  // Test set tracking
+  private var testSetTestCases: Map[String, List[String]] = Map.empty
+  private var announcedTestSets: Set[String] = Set.empty
+  private var matchedTestSets: Int = 0
+  private var uriMapsRegistered: Boolean = false
+
+  override def receive: Receive = {
+
+    case Parse(xqtsVersion, xqtsPath, features, specs, xmlVersions, xsdVersions, testSets, testCases, excludeTestSets, excludeTestCases) =>
+      val sender = context.sender()
+      logger.info(s"Parsing XQFTTS Catalog: ${xqtsPath.resolve(CATALOG_FILE)}...")
+      val matched = parseCatalog(sender, xqtsVersion, xqtsPath, testSets, testCases, excludeTestSets, excludeTestCases)
+      // Ensure URI maps are registered (in case catalog had no test groups)
+      if (!uriMapsRegistered) {
+        registerURIMaps()
+        uriMapsRegistered = true
+      }
+
+      logger.info(s"Parsed XQFTTS Catalog OK. Matched $matched test sets.")
+      sender ! ParseComplete(xqtsVersion, xqtsPath, matched)
+      context.stop(self)
+  }
+
+  private def parseCatalog(
+    xqtsRunner: ActorRef,
+    xqtsVersion: XQTSVersion,
+    xqtsPath: Path,
+    testSets: Either[Set[String], Pattern],
+    testCases: Either[Set[String], Pattern],
+    excludeTestSets: Set[String],
+    excludeTestCases: Set[String]
+  ): Int = {
+
+    def matchesTestSets(testSetName: String): Boolean = {
+      if (excludeTestSets.contains(testSetName)) return false
+      testSets match {
+        case Left(names) => names.isEmpty || names.contains(testSetName)
+        case Right(pattern) => pattern.matcher(testSetName).matches()
+      }
+    }
+
+    def matchesTestCases(testCaseName: String): Boolean = {
+      if (excludeTestCases.contains(testCaseName)) return false
+      testCases match {
+        case Left(names) => names.isEmpty || names.contains(testCaseName)
+        case Right(pattern) => pattern.matcher(testCaseName).matches()
+      }
+    }
+
+    val catalogPath = xqtsPath.resolve(CATALOG_FILE)
+
+    val bufIO = cats.effect.Resource.make(IO { ByteBuffer.allocate(xmlParserBufferSize) })(buf => IO { buf.clear() })
+    val fileIO = cats.effect.Resource.make(IO { Files.newByteChannel(catalogPath) })(channel => IO { channel.close() })
+    val asyncParserIO = cats.effect.Resource.make(IO { PARSER_FACTORY.createAsyncForByteBuffer() })(asyncReader => IO { asyncReader.close() })
+    val parseIO = bufIO.use(buf =>
+      fileIO.use(channel =>
+        asyncParserIO.use(asyncReader =>
+          IO {
+            parseAll(asyncReader.next(), asyncReader, xqtsPath, channel, buf, xqtsRunner, matchesTestSets, matchesTestCases)
+          }
+        )
+      )
+    )
+    parseIO.unsafeRunSync()(IORuntime.global)
+
+    matchedTestSets
+  }
+
+  @tailrec
+  @throws[XQTSParseException]
+  private def parseAll(
+    event: Int,
+    asyncReader: AsyncXMLStreamReader[AsyncByteBufferFeeder],
+    xqtsPath: Path,
+    channel: SeekableByteChannel,
+    buf: ByteBuffer,
+    xqtsRunner: ActorRef,
+    matchesTestSets: String => Boolean,
+    matchesTestCases: String => Boolean
+  ): Unit = {
+    event match {
+
+      case END_DOCUMENT =>
+        // Finalize any remaining open test sets
+        for ((tsName, tcNames) <- testSetTestCases) {
+          val testSetRef = TestSetRef(XQTS_FTTS_1_0, tsName, xqtsPath.resolve(CATALOG_FILE))
+          xqtsRunner ! ParsedTestSet(testSetRef, tcNames)
+        }
+        return
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_TEST_SUITE =>
+        // Read offset paths from catalog root attributes
+        asyncReader.getAttributeValueOpt(ATTR_XQUERY_QUERY_OFFSET_PATH).foreach(v => queryOffsetPath = v)
+        asyncReader.getAttributeValueOpt(ATTR_RESULT_OFFSET_PATH).foreach(v => resultOffsetPath = v)
+        asyncReader.getAttributeValueOpt(ATTR_SOURCE_OFFSET_PATH).foreach(v => sourceOffsetPath = v)
+        asyncReader.getAttributeValueOpt(ATTR_XQUERY_FILE_EXTENSION).foreach(v => queryFileExtension = v)
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_SOURCE && groupStack.isEmpty =>
+        // Source definition in the <sources> section
+        val id = asyncReader.getAttributeValue(ATTR_ID)
+        val fileName = asyncReader.getAttributeValue(ATTR_FILE_NAME)
+        if (id != null && fileName != null) {
+          sources = sources + (id -> xqtsPath.resolve(fileName))
+        }
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_STOPWORDS && groupStack.isEmpty =>
+        // Stop word definition: maps URI to local file path
+        val uri = asyncReader.getAttributeValue(ATTR_URI)
+        val fileName = asyncReader.getAttributeValue(ATTR_FILE_NAME)
+        if (uri != null && fileName != null) {
+          val resolvedPath = xqtsPath.resolve(fileName)
+          stopWordURIMap = stopWordURIMap + (uri -> resolvedPath)
+          logger.debug(s"Registered stop word URI mapping: $uri -> $resolvedPath")
+        }
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_THESAURUS && groupStack.isEmpty =>
+        // Thesaurus definition: maps URI to local file path
+        val uri = asyncReader.getAttributeValue(ATTR_URI)
+        val fileName = asyncReader.getAttributeValue(ATTR_FILE_NAME)
+        if (uri != null && fileName != null) {
+          val resolvedPath = xqtsPath.resolve(fileName)
+          thesaurusURIMap = thesaurusURIMap + (uri -> resolvedPath)
+          logger.debug(s"Registered thesaurus URI mapping: $uri -> $resolvedPath")
+        }
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_TEST_GROUP =>
+        // Register stop word and thesaurus URI maps before the first test group
+        // to ensure they're available before any test cases are sent to the runner.
+        if (!uriMapsRegistered) {
+          registerURIMaps()
+          uriMapsRegistered = true
+        }
+        val name = asyncReader.getAttributeValue(ATTR_NAME)
+        groupStack = groupStack :+ (if (name != null) name else s"group-${groupStack.size}")
+        currentFilePath = currentFilePath :+ Option(asyncReader.getAttributeValue(ATTR_FILE_PATH))
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_TEST_GROUP =>
+        val groupName = if (groupStack.nonEmpty) groupStack.last else "<unknown>"
+        // If this group had test cases, finalize it
+        if (testSetTestCases.contains(groupName)) {
+          val testSetRef = TestSetRef(XQTS_FTTS_1_0, groupName, xqtsPath.resolve(CATALOG_FILE))
+          xqtsRunner ! ParsedTestSet(testSetRef, testSetTestCases(groupName))
+          testSetTestCases = testSetTestCases - groupName
+        }
+        if (groupStack.nonEmpty) groupStack = groupStack.init
+        if (currentFilePath.nonEmpty) currentFilePath = currentFilePath.init
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_TEST_CASE =>
+        currentTestCaseName = asyncReader.getAttributeValueOpt(ATTR_NAME)
+        currentTestCaseFilePath = asyncReader.getAttributeValueOpt(ATTR_FILE_PATH)
+          .orElse(currentFilePath.reverse.collectFirst { case Some(fp) => fp })
+        currentTestCaseScenario = asyncReader.getAttributeValueOpt(ATTR_SCENARIO)
+        currentQueryName = None
+        currentInputFiles = List.empty
+        currentContextItem = None
+        currentOutputFiles = List.empty
+        currentExpectedErrors = List.empty
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_QUERY && currentTestCaseName.isDefined =>
+        currentQueryName = asyncReader.getAttributeValueOpt(ATTR_NAME)
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_INPUT_FILE && currentTestCaseName.isDefined =>
+        currentInputVariable = asyncReader.getAttributeValueOpt(ATTR_VARIABLE).orElse(Some("input-context"))
+        captureText = true
+        currentText = None
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_INPUT_FILE && currentTestCaseName.isDefined =>
+        captureText = false
+        val sourceId = currentText.map(_.trim).getOrElse("")
+        if (sourceId.nonEmpty) {
+          val variable = currentInputVariable.getOrElse("input-context")
+          currentInputFiles = currentInputFiles :+ (variable, sourceId)
+        }
+        currentText = None
+        currentInputVariable = None
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_CONTEXT_ITEM && currentTestCaseName.isDefined =>
+        captureText = true
+        currentText = None
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_CONTEXT_ITEM && currentTestCaseName.isDefined =>
+        captureText = false
+        currentText.map(_.trim).filter(_.nonEmpty).foreach { sourceId =>
+          currentContextItem = Some(sourceId)
+        }
+        currentText = None
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_OUTPUT_FILE && currentTestCaseName.isDefined =>
+        currentCompareType = asyncReader.getAttributeValueOpt(ATTR_COMPARE).orElse(Some(COMPARE_TEXT))
+        captureText = true
+        currentText = None
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_OUTPUT_FILE && currentTestCaseName.isDefined =>
+        captureText = false
+        val fileName = currentText.map(_.trim).getOrElse("")
+        if (fileName.nonEmpty) {
+          val filePath = currentTestCaseFilePath.getOrElse("")
+          val resolvedPath = xqtsPath.resolve(resultOffsetPath + filePath + fileName)
+          val compareType = currentCompareType.getOrElse(COMPARE_TEXT)
+          currentOutputFiles = currentOutputFiles :+ (compareType, resolvedPath)
+        }
+        currentText = None
+        currentCompareType = None
+
+      case START_ELEMENT if asyncReader.getLocalName == ELEM_EXPECTED_ERROR && currentTestCaseName.isDefined =>
+        captureText = true
+        currentText = None
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_EXPECTED_ERROR && currentTestCaseName.isDefined =>
+        captureText = false
+        currentText.map(_.trim).filter(_.nonEmpty).foreach { code =>
+          currentExpectedErrors = currentExpectedErrors :+ code
+        }
+        currentText = None
+
+      case END_ELEMENT if asyncReader.getLocalName == ELEM_TEST_CASE && currentTestCaseName.isDefined =>
+        // Build and dispatch the test case
+        val testCaseName = currentTestCaseName.get
+        val testSetName = if (groupStack.nonEmpty) groupStack.last else "unknown"
+
+        if (matchesTestSets(testSetName) && matchesTestCases(testCaseName)) {
+          val testSetRef = TestSetRef(XQTS_FTTS_1_0, testSetName, xqtsPath.resolve(CATALOG_FILE))
+
+          // Announce test set if first time
+          if (!announcedTestSets.contains(testSetName)) {
+            xqtsRunner ! ParsingTestSet(testSetRef)
+            announcedTestSets = announcedTestSets + testSetName
+            matchedTestSets = matchedTestSets + 1
+          }
+
+          // Build query path
+          val filePath = currentTestCaseFilePath.getOrElse("")
+          val queryPath = currentQueryName.map(qn => xqtsPath.resolve(queryOffsetPath + filePath + qn + queryFileExtension))
+
+          // Build environment from input files and context item
+          val inputSources = currentInputFiles.flatMap { case (variable, sourceId) =>
+            sources.get(sourceId).map { sourcePath =>
+              Source(
+                role = Some(ExternalVariableRole(variable)),
+                file = sourcePath,
+                uri = None
+              )
+            }
+          }
+          val contextSources = currentContextItem.flatMap { sourceId =>
+            sources.get(sourceId).map { sourcePath =>
+              Source(
+                role = Some(ContextItemRole),
+                file = sourcePath,
+                uri = None
+              )
+            }
+          }.toList
+          val envSources = contextSources ++ inputSources
+          val environment = if (envSources.nonEmpty) Some(Environment("env", sources = envSources)) else None
+
+          // Build assertions
+          val assertions: List[Result] = buildAssertions()
+
+          val result = if (assertions.size == 1) Some(assertions.head) else if (assertions.nonEmpty) Some(AnyOf(assertions)) else None
+
+          val testCase = TestCase(
+            file = xqtsPath.resolve(CATALOG_FILE),
+            name = testCaseName,
+            covers = "",
+            description = None,
+            environment = environment,
+            test = queryPath.map(Right(_)),
+            result = result
+          )
+
+          // Track and dispatch
+          testSetTestCases = testSetTestCases + (testSetName -> (testSetTestCases.getOrElse(testSetName, List.empty) :+ testCaseName))
+          xqtsRunner ! RunningTestCase(testSetRef, testCaseName)
+          testCaseRunnerRouter ! RunTestCase(testSetRef, testCase, xqtsRunner)
+        }
+
+        // Reset test case state
+        currentTestCaseName = None
+        currentTestCaseFilePath = None
+        currentTestCaseScenario = None
+        currentQueryName = None
+        currentInputFiles = List.empty
+        currentContextItem = None
+        currentOutputFiles = List.empty
+        currentExpectedErrors = List.empty
+
+      case CHARACTERS if captureText =>
+        val text = asyncReader.getText
+        currentText = Some(currentText.getOrElse("") + text)
+
+      case EVENT_INCOMPLETE =>
+        val bytesRead = channel.read(buf)
+        if (bytesRead == -1) {
+          asyncReader.getInputFeeder.endOfInput()
+        } else {
+          buf.flip()
+          asyncReader.getInputFeeder.feedInput(buf)
+        }
+
+      case _ => // ignore other events
+    }
+
+    parseAll(asyncReader.next(), asyncReader, xqtsPath, channel, buf, xqtsRunner, matchesTestSets, matchesTestCases)
+  }
+
+  /**
+    * Register stop word and thesaurus URI mappings on the ExistServer's global context
+    * attributes, so they're available via XQueryContext.getAttribute() during test execution.
+    */
+  private def registerURIMaps(): Unit = {
+    import scala.jdk.CollectionConverters._
+    if (stopWordURIMap.nonEmpty) {
+      val javaMap: java.util.Map[String, Path] = stopWordURIMap.asJava
+      existServer.globalContextAttributes = existServer.globalContextAttributes +
+        ("ft.stopWordURIMap" -> javaMap)
+      logger.info(s"Registered ${stopWordURIMap.size} stop word URI mappings")
+    }
+    if (thesaurusURIMap.nonEmpty) {
+      val javaMap: java.util.Map[String, Path] = thesaurusURIMap.asJava
+      existServer.globalContextAttributes = existServer.globalContextAttributes +
+        ("ft.thesaurusURIMap" -> javaMap)
+      logger.info(s"Registered ${thesaurusURIMap.size} thesaurus URI mappings")
+    }
+  }
+
+  /**
+    * Build assertions from the current test case's output files and expected errors.
+    */
+  private def buildAssertions(): List[Result] = {
+    val outputAssertions = currentOutputFiles.filter(_._2 != null).flatMap { case (compareType, path) =>
+      compareType match {
+        case COMPARE_XML =>
+          Some(AssertXml(Right(path)))
+        case COMPARE_FRAGMENT =>
+          // Fragment comparison normalizes whitespace in text nodes because
+          // XQFTTS expected outputs were generated by reference implementations
+          // with different line-wrapping/indentation conventions than eXist-db.
+          Some(AssertXml(Right(path), normalizeWhitespace = true))
+        case COMPARE_TEXT =>
+          Some(AssertXml(Right(path)))
+        case COMPARE_INSPECT | COMPARE_IGNORE =>
+          Some(AssertInspect) // cannot automatically verify; always passes
+        case _ =>
+          Some(AssertXml(Right(path)))
+      }
+    }
+
+    val errorAssertions = currentExpectedErrors.map(code => Error(code))
+
+    outputAssertions ++ errorAssertions
+  }
+}

--- a/src/main/scala/org/exist/xqts/runner/xqftts/package.scala
+++ b/src/main/scala/org/exist/xqts/runner/xqftts/package.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018  The eXist Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exist.xqts.runner
+
+import com.fasterxml.aalto.stax.InputFactoryImpl
+import com.fasterxml.aalto.{AsyncInputFeeder, AsyncXMLStreamReader}
+
+import javax.xml.XMLConstants
+
+package object xqftts {
+
+  // Catalog file constants
+  val CATALOG_FILE = "XQFTTSCatalog.xml"
+  val XQUERY_QUERY_OFFSET = "Queries/XQuery/"
+  val RESULT_OFFSET = "ExpectedTestResults/"
+  val XQUERY_FILE_EXT = ".xq"
+
+  // Element names (XQFTTS namespace: http://www.w3.org/2005/02/query-test-full-text)
+  val ELEM_TEST_SUITE = "test-suite"
+  val ELEM_SOURCES = "sources"
+  val ELEM_SOURCE = "source"
+  val ELEM_TEST_GROUP = "test-group"
+  val ELEM_GROUP_INFO = "GroupInfo"
+  val ELEM_TITLE = "title"
+  val ELEM_DESCRIPTION = "description"
+  val ELEM_TEST_CASE = "test-case"
+  val ELEM_QUERY = "query"
+  val ELEM_INPUT_FILE = "input-file"
+  val ELEM_INPUT_URI = "input-URI"
+  val ELEM_OUTPUT_FILE = "output-file"
+  val ELEM_CONTEXT_ITEM = "contextItem"
+  val ELEM_EXPECTED_ERROR = "expected-error"
+  val ELEM_SPEC_CITATION = "spec-citation"
+  val ELEM_STOPWORDS = "stopwords"
+  val ELEM_THESAURUS = "thesaurus"
+
+  // Attribute names
+  val ATTR_NAME = "name"
+  val ATTR_ID = "ID"
+  val ATTR_FILE_NAME = "FileName"
+  val ATTR_FILE_PATH = "FilePath"
+  val ATTR_SCENARIO = "scenario"
+  val ATTR_IS_XPATH2 = "is-XPath2"
+  val ATTR_CREATOR = "Creator"
+  val ATTR_COMPARE = "compare"
+  val ATTR_ROLE = "role"
+  val ATTR_VARIABLE = "variable"
+  val ATTR_DATE = "date"
+  val ATTR_XQUERY_QUERY_OFFSET_PATH = "XQueryQueryOffsetPath"
+  val ATTR_RESULT_OFFSET_PATH = "ResultOffsetPath"
+  val ATTR_XQUERY_FILE_EXTENSION = "XQueryFileExtension"
+  val ATTR_SOURCE_OFFSET_PATH = "SourceOffsetPath"
+  val ATTR_URI = "uri"
+
+  // Comparison types
+  val COMPARE_XML = "XML"
+  val COMPARE_FRAGMENT = "Fragment"
+  val COMPARE_TEXT = "Text"
+  val COMPARE_INSPECT = "Inspect"
+  val COMPARE_IGNORE = "Ignore"
+
+  // Scenario types
+  val SCENARIO_STANDARD = "standard"
+  val SCENARIO_PARSE_ERROR = "parse-error"
+  val SCENARIO_RUNTIME_ERROR = "runtime-error"
+
+  private[xqftts] val PARSER_FACTORY = new InputFactoryImpl
+
+  implicit class AsyncXMLStreamReaderPimp[F <: AsyncInputFeeder](asyncXmlStreamReader: AsyncXMLStreamReader[F]) {
+    def getAttributeValue(localName: String): String = asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName)
+    def getAttributeValueOpt(localName: String): Option[String] = Option(asyncXmlStreamReader.getAttributeValue(XMLConstants.NULL_NS_URI, localName))
+    def getAttributeValueOptNE(localName: String): Option[String] = getAttributeValueOpt(localName).filter(_.nonEmpty)
+  }
+}


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Adds `--xqts-version FTTS` to run the W3C XPath/XQuery Full-Text Test Suite (XQFTTS 1.0.4). Extracted from the QT4 bundle (#49) as a self-contained, suite-agnostic slice — it brings none of the QT4, XQuery-Update/sandpit, or EXPath changes that shared these files.

## What changed

- New `xqftts` package: `XQFTTSCatalogParserActor` parses the XQFTTS catalog (a different structure from the QT3 catalog) and its stop-word / thesaurus URI maps; `xqftts/package.scala` holds its element/attribute constants.
- New `XQTS_FTTS_1_0` version + download config (pinned to the stable `XQFTTS_1_0_4.zip` sha256) and parser dispatch in `XQTSRunner`.
- `XQTSRunnerActor` routes the FTTS catalog parser straight to the test-case runner (no test-set-parser pool) and hands it the `ExistServer`, so it can register the suite's stop-word / thesaurus URI maps as global context attributes — wired through a new `ExistConnection` context-attribute supplier in `ExistServer`.
- `AssertInspect` (an "Inspect" comparison that can't be auto-verified, so it passes) and an **additive** `normalizeWhitespace` flag on `AssertXml`, threaded into the XMLUnit comparison so XQFTTS Fragment comparisons collapse insignificant whitespace. The whitespace-only text-node filter stays unconditional, so **QT3 / 3.1 `assertXml` behavior is unchanged**.

## Validation

The suite loads and runs end-to-end:

```
Parsed XQFTTS Catalog OK. Matched 84 test sets.
Completed XQTS in 2839 ms
```

Aggregate over all 84 sets: **685 tests, 22 pass (3.2%), 663 fail, 0 errors, 0 skipped.**

The low pass rate is the expected **pre-implementation baseline**, not a runner issue: the failures are dominated by `XPST0003` (eXist's parser does not yet accept the `contains text` XQuery Full-Text syntax) and `FTST*` full-text static errors. The runner correctly parses the catalog, runs every test, and records eXist's parse/eval errors.

**This is the test harness for eXist-db/exist#6215 ("Implement W3C XQuery and XPath Full Text 3.0").** The current ~3% pass rate is the baseline against that engine work; it will climb as eXist-db/exist#6215 lands. This PR changes no existing-suite behavior and is safe to carry ahead of it.

## Test plan

- [x] `sbt compile` clean (warnings unchanged / confined to the new `xqftts` files).
- [x] XQFTTS suite runs end-to-end (84 sets, 685 tests); catalog parses; results serialize.
- [x] Verified the `normalizeWhitespace` change is additive — the whitespace-only node filter remains unconditional, so QT3 `assertXml` is unaffected.

## Risk and rollback

Additive: a new suite, a new assertion (`AssertInspect`), and an opt-in `normalizeWhitespace` flag. No change to the 3.1/HEAD suites. Reverting removes the `xqftts` package and the FTTS wiring.
