### PR TITLE
Wire up Maven Central publishing for the 2.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+# Triggered by a tag push (bare semver, e.g. 2.0.0, 2.0.0-RC3 — no 'v' prefix).
+# Publish target depends on which branch the tagged commit lives on:
+#   - an ancestor of main  -> GA release  -> publish to Maven Central
+#   - otherwise (develop)  -> RC/interim  -> publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish release artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine publish target
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "PUBLISH_TARGET=central" >> "$GITHUB_ENV"
+          else
+            echo "PUBLISH_TARGET=ghp" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+        with:
+          sbt-runner-version: '1.12.11'
+
+      - name: Import GPG key
+        env:
+          EXISTDB_RELEASE_KEY: ${{ secrets.EXISTDB_RELEASE_KEY }}
+        run: echo "$EXISTDB_RELEASE_KEY" | base64 --decode | gpg --batch --import
+
+      - name: Publish to Maven Central
+        if: env.PUBLISH_TARGET == 'central'
+        env:
+          PGP_PASSPHRASE: ${{ secrets.EXISTDB_RELEASE_KEY_PASSPHRASE }}
+          CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+        run: sbt publishSigned sonatypeBundleRelease
+
+      - name: Publish to GitHub Packages
+        if: env.PUBLISH_TARGET == 'ghp'
+        env:
+          PGP_PASSPHRASE: ${{ secrets.EXISTDB_RELEASE_KEY_PASSPHRASE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_TO_GITHUB: 'true'
+        run: sbt publishSigned

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import ReleaseTransformations._
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 name := "exist-xqts-runner"
 
@@ -48,7 +49,7 @@ developers := List(
 versionScheme := Some("semver-spec")
 
 libraryDependencies ++= {
-  val existV = "7.0.0-SNAPSHOT"
+  val existV = "7.0.0-beta3"
 
   Seq(
     "org.apache.pekko" %% "pekko-actor" % "1.3.0",
@@ -60,7 +61,7 @@ libraryDependencies ++= {
     "org.apache.ant" % "ant-junit" % "1.10.15", // used for formatting junit style report
 
     "net.sf.saxon" % "Saxon-HE" % "12.5",
-    "org.exist-db" % "exist-core" % existV changing(),
+    "org.exist-db" % "exist-core" % existV,
     "org.xmlunit" % "xmlunit-core" % "2.11.0",
 
     "org.slf4j" % "slf4j-api" % "2.0.17",
@@ -160,6 +161,8 @@ addArtifact(Compile / assembly / artifact, assembly)
 // Publish to Maven Repo
 publishMavenStyle := true
 
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
+
 // Use GitHub Packages if GITHUB_TOKEN is set, otherwise use local connection in credentials file
 credentials += {
   sys.env.get("GITHUB_TOKEN") match {
@@ -167,6 +170,14 @@ credentials += {
     case _ => Credentials(Path.userHome / ".ivy2" / ".credentials")
   }
 }
+
+// Sonatype Central Portal credentials, used when publishing releases there (see PUBLISH_TO_GITHUB below)
+credentials += Credentials(
+  "Sonatype Nexus Repository Manager",
+  sonatypeCredentialHost.value,
+  sys.env.getOrElse("CENTRAL_TOKEN_USERNAME", ""),
+  sys.env.getOrElse("CENTRAL_TOKEN_PASSWORD", "")
+)
 
 // Toggle publishing target via environment variable
 val useGitHub = sys.env.get("PUBLISH_TO_GITHUB").isDefined
@@ -177,10 +188,10 @@ publishTo := {
   } else if (useGitHub) {
     Some("releases" at "https://maven.pkg.github.com/exist-db/exist-xqts-runner")
   } else {
-    localStaging.value
+    sonatypePublishToBundle.value
   }
 }
-  
+
 Test / publishArtifact := false
 
 releaseCrossBuild := false
@@ -191,22 +202,18 @@ releaseTagName := s"${if (releaseUseGlobalVersion.value) (ThisBuild / version).v
 
 releaseIgnoreUntrackedFiles := true
 
-releaseProcess := {
-  val base = Seq[ReleaseStep](
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    releaseStepCommand("publishSigned"),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
-
-  if (useGitHub) base
-  else checkSnapshotDependencies +: base
-}
+// Publishing happens in CI on tag push (see .github/workflows/release.yml), not as part of this process.
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
 
 useCoursier := false


### PR DESCRIPTION
## Summary
- Pin `exist-core` to the released `7.0.0-beta3` instead of the `7.0.0-SNAPSHOT changing()` dependency — Sonatype Central's Publisher Portal rejects release deployments that depend on a SNAPSHOT artifact.
- Configure `sbt-sonatype` for the Central Portal (`sonatypeCredentialHost`/`sonatypePublishToBundle`/Central credentials from `CENTRAL_TOKEN_USERNAME`/`CENTRAL_TOKEN_PASSWORD`).
- Add `.github/workflows/release.yml`, a tag-triggered workflow that decides the publish target by whether the tagged commit is an ancestor of `main`: tags on `main` (the GA release branch) publish to Maven Central, tags cut directly on `develop` (RCs/interim, today's convention) keep publishing to GitHub Packages only, unchanged.
- Publishing moves entirely into CI — `releaseProcess` in `build.sbt` no longer runs `publishSigned` itself, it just handles the version bump/tag/push; make `checkSnapshotDependencies` unconditional as a safety net now that there are no SNAPSHOT dependencies left.

## Why exist-core 7.0.0-beta3 (not SNAPSHOT, not GA)
exist-core 7.0.0 hasn't shipped as GA yet (latest is `eXist-7.0.0-beta3`, already published on Maven Central). A local `fn-*` XQTS comparison (22k tests) between the current SNAPSHOT and `beta3` found ~19 real regressions, all in `fn-xml-to-json` (beta3 fails to raise `FOJS0006` in some cases that the SNAPSHOT correctly does), plus a feature-detection shift affecting `fn-load-xquery-module` applicability.

This is low risk for the primary consumer: `exist-db/exist`'s own `exist-xqts` Maven module depends on `exist-xqts-runner` but explicitly *excludes* its transitive `exist-core` and substitutes the reactor's own freshly-built `exist-core` instead (see `exist-xqts/pom.xml`), so the version pinned here never actually executes in that CI path. It only matters for anyone running the published assembly jar standalone (it boots an embedded `exist-core` instance in-process — there's no remote-server mode).

## Test plan
- [x] `sbt assembly` builds successfully against `exist-core:7.0.0-beta3`
- [x] `sbt "show sonatypeCredentialHost" "show publishTo"` resolves to `central.sonatype.com` / the expected snapshot feed
- [x] `sbt "show releaseProcess"` shows the expected 9 steps with no `publishSigned`
- [ ] Merge, then fast-forward `main` to `develop` and cut the `2.0.0` tag there to exercise `release.yml`'s Maven Central path end-to-end
- [ ] Confirm `2.0.0` artifacts (including sources/javadoc jars) appear on Maven Central